### PR TITLE
tweak TOML version catalog conventions

### DIFF
--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -7,4 +7,3 @@ dependencyResolutionManagement {
         }
     }
 }
-

--- a/buildSrc/src/main/kotlin/io.github.mikewacker.drift.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.github.mikewacker.drift.java-conventions.gradle.kts
@@ -20,9 +20,9 @@ dependencies {
     errorprone(libs.errorprone.core)
 
     testImplementation(libs.assertj.core)
-    testImplementation(libs.junit.jupiter.api)
+    testImplementation(libs.junitJupiter.api)
 
-    testRuntimeOnly(libs.junit.jupiter.engine)
+    testRuntimeOnly(libs.junitJupiter.engine)
 }
 
 java {
@@ -39,7 +39,7 @@ tasks.javadoc {
 
 spotless {
     java {
-        palantirJavaFormat("2.39.0")
+        palantirJavaFormat(libs.versions.plugin.spotless.palantir.get())
     }
 }
 

--- a/drift-api/build.gradle.kts
+++ b/drift-api/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    api(libs.immutables.value.annotations)
+    api(libs.immutables.annotations)
     api(libs.jackson.annotations)
     api(libs.jackson.core)
     api(libs.jackson.databind)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,24 +1,25 @@
 [versions]
 assertj = "3.24.2"
 errorprone = "2.24.0"
+guava = "33.0.0-jre"
 immutables = "2.10.0"
 jackson = "2.16.1"
-junit-jupiter = "5.10.1"
-guava = "33.0.0-jre"
+junitJupiter = "5.10.1"
 
 plugin-errorprone = "3.1.0"
 plugin-spotless = "6.23.3"
+plugin-spotless-palantir = "2.39.0"
 
 [libraries]
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 errorprone-core = { module = "com.google.errorprone:error_prone_core", version.ref = "errorprone" }
-immutables-value-annotations = { module = "org.immutables:value-annotations", version.ref = "immutables" }
+guava-testlib = { module = "com.google.guava:guava-testlib", version.ref = "guava" }
+immutables-annotations = { module = "org.immutables:value-annotations", version.ref = "immutables" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson" }
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
-junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit-jupiter" }
-junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit-jupiter" }
-guava-testlib = { module = "com.google.guava:guava-testlib", version.ref = "guava" }
+junitJupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junitJupiter" }
+junitJupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitJupiter" }
 
 plugin-errorprone = { module = "net.ltgt.errorprone:net.ltgt.errorprone.gradle.plugin", version.ref = "plugin-errorprone" }
 plugin-spotless = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "plugin-spotless" }


### PR DESCRIPTION
- two-level alias: group, then artifact
- prefer one word, but use camel case if multiple words are better (e.g., `junitJupiter`)
- (plugins also use a two-level alias: `plugin`, then a descriptive name)