### PR TITLE
add main drift module, split out publishing conventions

### DIFF
--- a/buildSrc/src/main/kotlin/io.github.mikewacker.drift.java-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.github.mikewacker.drift.java-conventions.gradle.kts
@@ -1,14 +1,10 @@
 import org.gradle.accessors.dm.LibrariesForLibs
 
 plugins {
-    `java-library`
-    `maven-publish`
-    signing
+    java
     id("com.diffplug.spotless")
     id("net.ltgt.errorprone")
 }
-
-/* conventions */
 
 repositories {
     mavenCentral()
@@ -29,12 +25,6 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)
     }
-    withSourcesJar()
-    withJavadocJar()
-}
-
-tasks.javadoc {
-    (options as StandardJavadocDocletOptions).addBooleanOption("Werror", true)
 }
 
 spotless {
@@ -49,67 +39,4 @@ tasks.withType<JavaCompile> {
 
 tasks.named<Test>("test") {
     useJUnitPlatform()
-}
-
-/* publishing */
-
-group = "io.github.mikewacker.drift"
-version = "0.0.3-SNAPSHOT"
-
-publishing {
-    publications {
-        create<MavenPublication>("mavenJava") {
-            from(components["java"])
-            versionMapping {
-                usage("java-api") {
-                    fromResolutionOf("runtimeClasspath")
-                }
-                usage("java-runtime") {
-                    fromResolutionResult()
-                }
-            }
-            pom {
-                url = "https://github.com/mikewacker/drift"
-                licenses {
-                    license {
-                        name = "MIT License"
-                        url = "https://opensource.org/license/mit/"
-                    }
-                }
-                developers {
-                    developer {
-                        id = "mikewacker"
-                        name = "Mike Wacker"
-                        email = "11431865+mikewacker@users.noreply.github.com"
-                        url = "https://github.com/mikewacker"
-                    }
-                }
-                scm {
-                    connection = "scm:git:git://github.com/mikewacker/drift.git"
-                    developerConnection = "scm:git:ssh://github.com:mikewacker/drift.git"
-                    url = "https://github.com/mikewacker/drift/tree/main"
-                }
-            }
-        }
-    }
-    repositories {
-        maven {
-            name = "Ossrh"
-            url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-            credentials {
-                val ossrhUsername: String? by project
-                val ossrhToken: String? by project
-                username = ossrhUsername
-                password = ossrhToken
-            }
-        }
-    }
-}
-
-signing {
-    val signingKeyId: String? by project
-    val signingKey: String? by project
-    val signingPassword: String? by project
-    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
-    sign(publishing.publications["mavenJava"])
 }

--- a/buildSrc/src/main/kotlin/io.github.mikewacker.drift.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.github.mikewacker.drift.publish-conventions.gradle.kts
@@ -1,0 +1,75 @@
+plugins {
+    java
+    `maven-publish`
+    signing
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+tasks.javadoc {
+    (options as StandardJavadocDocletOptions).addBooleanOption("Werror", true)
+}
+
+group = "io.github.mikewacker.drift"
+version = "0.0.3-SNAPSHOT"
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            versionMapping {
+                usage("java-api") {
+                    fromResolutionOf("runtimeClasspath")
+                }
+                usage("java-runtime") {
+                    fromResolutionResult()
+                }
+            }
+            pom {
+                url = "https://github.com/mikewacker/drift"
+                licenses {
+                    license {
+                        name = "MIT License"
+                        url = "https://opensource.org/license/mit/"
+                    }
+                }
+                developers {
+                    developer {
+                        id = "mikewacker"
+                        name = "Mike Wacker"
+                        email = "11431865+mikewacker@users.noreply.github.com"
+                        url = "https://github.com/mikewacker"
+                    }
+                }
+                scm {
+                    connection = "scm:git:git://github.com/mikewacker/drift.git"
+                    developerConnection = "scm:git:ssh://github.com:mikewacker/drift.git"
+                    url = "https://github.com/mikewacker/drift/tree/main"
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            name = "Ossrh"
+            url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+            credentials {
+                val ossrhUsername: String? by project
+                val ossrhToken: String? by project
+                username = ossrhUsername
+                password = ossrhToken
+            }
+        }
+    }
+}
+
+signing {
+    val signingKeyId: String? by project
+    val signingKey: String? by project
+    val signingPassword: String? by project
+    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+    sign(publishing.publications["mavenJava"])
+}

--- a/drift-api/build.gradle.kts
+++ b/drift-api/build.gradle.kts
@@ -1,5 +1,7 @@
 plugins {
+    `java-library`
     id("io.github.mikewacker.drift.java-conventions")
+    id("io.github.mikewacker.drift.publish-conventions")
 }
 
 dependencies {
@@ -17,7 +19,7 @@ publishing {
     publications.named<MavenPublication>("mavenJava") {
         pom {
             name = "Drift API"
-            description = "Lightweight interfaces that define a JSON API."
+            description = "Lightweight interfaces and utilities that define a JSON API."
         }
     }
 }

--- a/drift-testlib/build.gradle.kts
+++ b/drift-testlib/build.gradle.kts
@@ -1,5 +1,7 @@
 plugins {
+    `java-library`
     id("io.github.mikewacker.drift.java-conventions")
+    id("io.github.mikewacker.drift.publish-conventions")
 }
 
 dependencies {

--- a/drift/build.gradle.kts
+++ b/drift/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    `java-library`
+    id("io.github.mikewacker.drift.java-conventions")
+    id("io.github.mikewacker.drift.publish-conventions")
+}
+
+dependencies {
+}
+
+publishing {
+    publications.named<MavenPublication>("mavenJava") {
+        pom {
+            name = "Drift"
+            description = "Lightweight, all-in-one library to rapidly prototype a JSON API."
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,3 @@
 rootProject.name = "drift"
 
-include("drift-api", "drift-testlib")
+include("drift-api", "drift", "drift-testlib")


### PR DESCRIPTION
Notes
- The `drift` module is initially empty, but it is set up for publishing.
- Context: I may also add an `example` module later.
    - It could be either an `application` or a `java-library` with tests.
    - It won't be published.
    - It doesn't need to follow strict JavaDoc rules (and it also doesn't need source or javadoc JARs).  
- The structure of the split largely follows from the above context.
- (Also include a slight update to the `drift-api` description, while I'm here.)