### PR TITLE
tests for BackendDispatcher

### DIFF
--- a/drift/src/test/java/io/github/mikewacker/drift/backend/BackendDispatcherTest.java
+++ b/drift/src/test/java/io/github/mikewacker/drift/backend/BackendDispatcherTest.java
@@ -1,0 +1,69 @@
+package io.github.mikewacker.drift.backend;
+
+import static io.github.mikewacker.drift.testing.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.mikewacker.drift.api.HttpOptional;
+import io.github.mikewacker.drift.client.JsonApiClient;
+import io.github.mikewacker.drift.testing.server.MockServer;
+import io.github.mikewacker.drift.testing.server.TestServer;
+import io.github.mikewacker.drift.testing.server.TestUndertowServer;
+import java.io.IOException;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.SocketPolicy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public final class BackendDispatcherTest {
+
+    @RegisterExtension
+    private static final TestServer<?> frontendServer = TestUndertowServer.register("frontend", ProxyEndpoint::create);
+
+    @RegisterExtension
+    private static final MockServer backendServer = MockServer.register("backend");
+
+    @Test
+    public void backendRequest_StatusCodeResponse() throws IOException {
+        backendServer.enqueue(new MockResponse());
+        int statusCode = executeRequestWithStatusCodeResponse();
+        assertThat(statusCode).isEqualTo(200);
+    }
+
+    @Test
+    public void backendRequest_JsonValueResponse() throws IOException {
+        backendServer.enqueue(
+                new MockResponse().setHeader("Content-Type", "application/json").setBody("\"test\""));
+        HttpOptional<String> maybeText = executeRequestWithJsonValueResponse();
+        assertThat(maybeText).hasValue("test");
+    }
+
+    @Test
+    public void backendRequest_RequestFails() throws IOException {
+        backendServer.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+        int statusCode = executeRequestWithStatusCodeResponse();
+        assertThat(statusCode).isEqualTo(502);
+    }
+
+    @Test
+    public void backendRequest_DeserializeResponseFails() throws IOException {
+        backendServer.enqueue(
+                new MockResponse().setHeader("Content-Type", "application/json").setBody("{"));
+        HttpOptional<String> maybeText = executeRequestWithJsonValueResponse();
+        assertThat(maybeText).isEmptyWithErrorCode(502);
+    }
+
+    private static int executeRequestWithStatusCodeResponse() throws IOException {
+        return JsonApiClient.requestBuilder()
+                .get(frontendServer.url("/status-code"))
+                .build()
+                .execute();
+    }
+
+    private static HttpOptional<String> executeRequestWithJsonValueResponse() throws IOException {
+        return JsonApiClient.requestBuilder(new TypeReference<String>() {})
+                .get(frontendServer.url("/text"))
+                .build()
+                .execute();
+    }
+}

--- a/drift/src/test/java/io/github/mikewacker/drift/backend/ProxyApi.java
+++ b/drift/src/test/java/io/github/mikewacker/drift/backend/ProxyApi.java
@@ -1,0 +1,12 @@
+package io.github.mikewacker.drift.backend;
+
+import io.github.mikewacker.drift.api.Dispatcher;
+import io.github.mikewacker.drift.api.Sender;
+
+/** API methods for testing. */
+interface ProxyApi {
+
+    void proxyStatusCode(Sender.StatusCode sender, Dispatcher dispatcher);
+
+    void proxyText(Sender.Value<String> sender, Dispatcher dispatcher);
+}

--- a/drift/src/test/java/io/github/mikewacker/drift/backend/ProxyEndpoint.java
+++ b/drift/src/test/java/io/github/mikewacker/drift/backend/ProxyEndpoint.java
@@ -1,0 +1,27 @@
+package io.github.mikewacker.drift.backend;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.mikewacker.drift.endpoint.HttpMethod;
+import io.github.mikewacker.drift.endpoint.UndertowJsonApiHandler;
+import io.github.mikewacker.drift.endpoint.UndertowRouter;
+import io.undertow.server.HttpHandler;
+
+/** Endpoint for {@code ProxyApi}. */
+final class ProxyEndpoint {
+
+    public static HttpHandler create() {
+        ProxyApi proxyApi = ProxyService.create();
+
+        HttpHandler statusCodeHandler = UndertowJsonApiHandler.builder().build(proxyApi::proxyStatusCode);
+        HttpHandler textHandler =
+                UndertowJsonApiHandler.builder(new TypeReference<String>() {}).build(proxyApi::proxyText);
+
+        return UndertowRouter.builder()
+                .addRoute(HttpMethod.GET, "/status-code", statusCodeHandler)
+                .addRoute(HttpMethod.GET, "/text", textHandler)
+                .build();
+    }
+
+    // static class
+    private ProxyEndpoint() {}
+}

--- a/drift/src/test/java/io/github/mikewacker/drift/backend/ProxyService.java
+++ b/drift/src/test/java/io/github/mikewacker/drift/backend/ProxyService.java
@@ -17,7 +17,8 @@ final class ProxyService implements ProxyApi {
 
     @Override
     public void proxyStatusCode(Sender.StatusCode sender, Dispatcher dispatcher) {
-        backendDispatcher.requestBuilder()
+        backendDispatcher
+                .requestBuilder()
                 .get(TestServer.get("backend").rootUrl())
                 .build()
                 .dispatch(sender, dispatcher, this::onStatusCodeReceived);
@@ -25,7 +26,8 @@ final class ProxyService implements ProxyApi {
 
     @Override
     public void proxyText(Sender.Value<String> sender, Dispatcher dispatcher) {
-        backendDispatcher.requestBuilder(new TypeReference<String>() {})
+        backendDispatcher
+                .requestBuilder(new TypeReference<String>() {})
                 .get(TestServer.get("backend").rootUrl())
                 .build()
                 .dispatch(sender, dispatcher, this::onTextReceived);

--- a/drift/src/test/java/io/github/mikewacker/drift/backend/ProxyService.java
+++ b/drift/src/test/java/io/github/mikewacker/drift/backend/ProxyService.java
@@ -1,0 +1,43 @@
+package io.github.mikewacker.drift.backend;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.mikewacker.drift.api.Dispatcher;
+import io.github.mikewacker.drift.api.HttpOptional;
+import io.github.mikewacker.drift.api.Sender;
+import io.github.mikewacker.drift.testing.server.TestServer;
+
+/** Service for {@code ProxyApi} that uses a {@code BackendDispatcher}. */
+final class ProxyService implements ProxyApi {
+
+    private final BackendDispatcher backendDispatcher = BackendDispatcher.create();
+
+    public static ProxyApi create() {
+        return new ProxyService();
+    }
+
+    @Override
+    public void proxyStatusCode(Sender.StatusCode sender, Dispatcher dispatcher) {
+        backendDispatcher.requestBuilder()
+                .get(TestServer.get("backend").rootUrl())
+                .build()
+                .dispatch(sender, dispatcher, this::onStatusCodeReceived);
+    }
+
+    @Override
+    public void proxyText(Sender.Value<String> sender, Dispatcher dispatcher) {
+        backendDispatcher.requestBuilder(new TypeReference<String>() {})
+                .get(TestServer.get("backend").rootUrl())
+                .build()
+                .dispatch(sender, dispatcher, this::onTextReceived);
+    }
+
+    private void onStatusCodeReceived(Sender.StatusCode sender, int statusCode, Dispatcher dispatcher) {
+        sender.send(statusCode);
+    }
+
+    private void onTextReceived(Sender.Value<String> sender, HttpOptional<String> maybeText, Dispatcher dispatcher) {
+        sender.send(maybeText);
+    }
+
+    private ProxyService() {}
+}


### PR DESCRIPTION
Can add these now that the `endpoint` package was implemented. (It wasn't implemented yet when `BackendDispatcher` was added.)