### PR TITLE
removed unneeded param for signing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,5 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
           ORG_GRADLE_PROJECT_ossrhToken: ${{ secrets.OSSRH_TOKEN }}
-          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}

--- a/buildSrc/src/main/kotlin/io.github.mikewacker.drift.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/io.github.mikewacker.drift.publish-conventions.gradle.kts
@@ -54,7 +54,7 @@ publishing {
     }
     repositories {
         maven {
-            name = "Ossrh"
+            name = "ossrh"
             url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
             credentials {
                 val ossrhUsername: String? by project
@@ -67,9 +67,8 @@ publishing {
 }
 
 signing {
-    val signingKeyId: String? by project
     val signingKey: String? by project
     val signingPassword: String? by project
-    useInMemoryPgpKeys(signingKeyId, signingKey, signingPassword)
+    useInMemoryPgpKeys(signingKey, signingPassword)
     sign(publishing.publications["mavenJava"])
 }


### PR DESCRIPTION
You only need a key ID if it's in-memory *subkey*. Verified locally w/ `./gradlew signMavenJavaPublication`.