### PR TITLE
extend drift-api interfaces to include up to eight args

### DIFF
--- a/drift-api/src/main/java/io/github/mikewacker/drift/api/ApiHandler.java
+++ b/drift-api/src/main/java/io/github/mikewacker/drift/api/ApiHandler.java
@@ -112,4 +112,134 @@ public interface ApiHandler {
          */
         void handleRequest(S sender, A1 arg1, A2 arg2, A3 arg3, A4 arg4, Dispatcher dispatcher) throws Exception;
     }
+
+    /**
+     * Asynchronous API handler for a request with five arguments.
+     *
+     * @param <S> the interface for the response sender
+     * @param <A1> the type of the first argument
+     * @param <A2> the type of the second argument
+     * @param <A3> the type of the third argument
+     * @param <A4> the type of the fourth argument
+     * @param <A5> the type of the fifth argument
+     */
+    @FunctionalInterface
+    interface FiveArg<S extends Sender, A1, A2, A3, A4, A5> extends ApiHandler {
+
+        /**
+         * Handles an API request, sending the response or dispatching the request.
+         *
+         * @param sender the response sender, for when the response can be sent
+         * @param arg1 the first argument for the API request
+         * @param arg2 the second argument for the API request
+         * @param arg3 the third argument for the API request
+         * @param arg4 the fourth argument for the API request
+         * @param arg5 the fifth argument for the API request
+         * @param dispatcher the request dispatcher, for when the response cannot be sent yet
+         * @throws Exception for any exception that this handler may throw
+         */
+        void handleRequest(S sender, A1 arg1, A2 arg2, A3 arg3, A4 arg4, A5 arg5, Dispatcher dispatcher)
+                throws Exception;
+    }
+
+    /**
+     * Asynchronous API handler for a request with six arguments.
+     *
+     * @param <S> the interface for the response sender
+     * @param <A1> the type of the first argument
+     * @param <A2> the type of the second argument
+     * @param <A3> the type of the third argument
+     * @param <A4> the type of the fourth argument
+     * @param <A5> the type of the fifth argument
+     * @param <A6> the type of the sixth argument
+     */
+    @FunctionalInterface
+    interface SixArg<S extends Sender, A1, A2, A3, A4, A5, A6> extends ApiHandler {
+
+        /**
+         * Handles an API request, sending the response or dispatching the request.
+         *
+         * @param sender the response sender, for when the response can be sent
+         * @param arg1 the first argument for the API request
+         * @param arg2 the second argument for the API request
+         * @param arg3 the third argument for the API request
+         * @param arg4 the fourth argument for the API request
+         * @param arg5 the fifth argument for the API request
+         * @param arg6 the sixth argument for the API request
+         * @param dispatcher the request dispatcher, for when the response cannot be sent yet
+         * @throws Exception for any exception that this handler may throw
+         */
+        void handleRequest(S sender, A1 arg1, A2 arg2, A3 arg3, A4 arg4, A5 arg5, A6 arg6, Dispatcher dispatcher)
+                throws Exception;
+    }
+
+    /**
+     * Asynchronous API handler for a request with seven arguments.
+     *
+     * @param <S> the interface for the response sender
+     * @param <A1> the type of the first argument
+     * @param <A2> the type of the second argument
+     * @param <A3> the type of the third argument
+     * @param <A4> the type of the fourth argument
+     * @param <A5> the type of the fifth argument
+     * @param <A6> the type of the sixth argument
+     * @param <A7> the type of the seventh argument
+     */
+    @FunctionalInterface
+    interface SevenArg<S extends Sender, A1, A2, A3, A4, A5, A6, A7> extends ApiHandler {
+
+        /**
+         * Handles an API request, sending the response or dispatching the request.
+         *
+         * @param sender the response sender, for when the response can be sent
+         * @param arg1 the first argument for the API request
+         * @param arg2 the second argument for the API request
+         * @param arg3 the third argument for the API request
+         * @param arg4 the fourth argument for the API request
+         * @param arg5 the fifth argument for the API request
+         * @param arg6 the sixth argument for the API request
+         * @param arg7 the seventh argument for the API request
+         * @param dispatcher the request dispatcher, for when the response cannot be sent yet
+         * @throws Exception for any exception that this handler may throw
+         */
+        void handleRequest(
+                S sender, A1 arg1, A2 arg2, A3 arg3, A4 arg4, A5 arg5, A6 arg6, A7 arg7, Dispatcher dispatcher)
+                throws Exception;
+    }
+
+    /**
+     * Asynchronous API handler for a request with eight arguments.
+     *
+     * @param <S> the interface for the response sender
+     * @param <A1> the type of the first argument
+     * @param <A2> the type of the second argument
+     * @param <A3> the type of the third argument
+     * @param <A4> the type of the fourth argument
+     * @param <A5> the type of the fifth argument
+     * @param <A6> the type of the sixth argument
+     * @param <A7> the type of the seventh argument
+     * @param <A8> the type of the eighth argument
+     */
+    @FunctionalInterface
+    interface EightArg<S extends Sender, A1, A2, A3, A4, A5, A6, A7, A8> extends ApiHandler {
+
+        /**
+         * Handles an API request, sending the response or dispatching the request.
+         *
+         * @param sender the response sender, for when the response can be sent
+         * @param arg1 the first argument for the API request
+         * @param arg2 the second argument for the API request
+         * @param arg3 the third argument for the API request
+         * @param arg4 the fourth argument for the API request
+         * @param arg5 the fifth argument for the API request
+         * @param arg6 the sixth argument for the API request
+         * @param arg7 the seventh argument for the API request
+         * @param arg8 the eighth argument for the API request
+         * @param dispatcher the request dispatcher, for when the response cannot be sent yet
+         * @throws Exception for any exception that this handler may throw
+         */
+        void handleRequest(
+                S sender, A1 arg1, A2 arg2, A3 arg3, A4 arg4, A5 arg5, A6 arg6, A7 arg7, A8 arg8, Dispatcher dispatcher)
+                throws Exception;
+    }
 }

--- a/drift-api/src/main/java/io/github/mikewacker/drift/api/Dispatcher.java
+++ b/drift-api/src/main/java/io/github/mikewacker/drift/api/Dispatcher.java
@@ -105,6 +105,122 @@ public interface Dispatcher {
             S sender, A1 arg1, A2 arg2, A3 arg3, A4 arg4, ApiHandler.FourArg<S, A1, A2, A3, A4> handler);
 
     /**
+     * Dispatches this request to the worker thread pool.
+     *
+     * @param sender the response sender, for when the response can be sent
+     * @param arg1 the first argument to dispatch
+     * @param arg2 the second argument to dispatch
+     * @param arg3 the third argument to dispatch
+     * @param arg4 the fourth argument to dispatch
+     * @param arg5 the fifth argument to dispatch
+     * @param handler the API handler for the dispatched request
+     * @param <S> the interface for the response sender
+     * @param <A1> the type of the first argument
+     * @param <A2> the type of the second argument
+     * @param <A3> the type of the third argument
+     * @param <A4> the type of the fourth argument
+     * @param <A5> the type of the fifth argument
+     */
+    <S extends Sender, A1, A2, A3, A4, A5> void dispatch(
+            S sender, A1 arg1, A2 arg2, A3 arg3, A4 arg4, A5 arg5, ApiHandler.FiveArg<S, A1, A2, A3, A4, A5> handler);
+
+    /**
+     * Dispatches this request to the worker thread pool.
+     *
+     * @param sender the response sender, for when the response can be sent
+     * @param arg1 the first argument to dispatch
+     * @param arg2 the second argument to dispatch
+     * @param arg3 the third argument to dispatch
+     * @param arg4 the fourth argument to dispatch
+     * @param arg5 the fifth argument to dispatch
+     * @param arg6 the sixth argument to dispatch
+     * @param handler the API handler for the dispatched request
+     * @param <S> the interface for the response sender
+     * @param <A1> the type of the first argument
+     * @param <A2> the type of the second argument
+     * @param <A3> the type of the third argument
+     * @param <A4> the type of the fourth argument
+     * @param <A5> the type of the fifth argument
+     * @param <A6> the type of the sixth argument
+     */
+    <S extends Sender, A1, A2, A3, A4, A5, A6> void dispatch(
+            S sender,
+            A1 arg1,
+            A2 arg2,
+            A3 arg3,
+            A4 arg4,
+            A5 arg5,
+            A6 arg6,
+            ApiHandler.SixArg<S, A1, A2, A3, A4, A5, A6> handler);
+
+    /**
+     * Dispatches this request to the worker thread pool.
+     *
+     * @param sender the response sender, for when the response can be sent
+     * @param arg1 the first argument to dispatch
+     * @param arg2 the second argument to dispatch
+     * @param arg3 the third argument to dispatch
+     * @param arg4 the fourth argument to dispatch
+     * @param arg5 the fifth argument to dispatch
+     * @param arg6 the sixth argument to dispatch
+     * @param arg7 the seventh argument to dispatch
+     * @param handler the API handler for the dispatched request
+     * @param <S> the interface for the response sender
+     * @param <A1> the type of the first argument
+     * @param <A2> the type of the second argument
+     * @param <A3> the type of the third argument
+     * @param <A4> the type of the fourth argument
+     * @param <A5> the type of the fifth argument
+     * @param <A6> the type of the sixth argument
+     * @param <A7> the type of the seventh argument
+     */
+    <S extends Sender, A1, A2, A3, A4, A5, A6, A7> void dispatch(
+            S sender,
+            A1 arg1,
+            A2 arg2,
+            A3 arg3,
+            A4 arg4,
+            A5 arg5,
+            A6 arg6,
+            A7 arg7,
+            ApiHandler.SevenArg<S, A1, A2, A3, A4, A5, A6, A7> handler);
+
+    /**
+     * Dispatches this request to the worker thread pool.
+     *
+     * @param sender the response sender, for when the response can be sent
+     * @param arg1 the first argument to dispatch
+     * @param arg2 the second argument to dispatch
+     * @param arg3 the third argument to dispatch
+     * @param arg4 the fourth argument to dispatch
+     * @param arg5 the fifth argument to dispatch
+     * @param arg6 the sixth argument to dispatch
+     * @param arg7 the seventh argument to dispatch
+     * @param arg8 the eighth argument to dispatch
+     * @param handler the API handler for the dispatched request
+     * @param <S> the interface for the response sender
+     * @param <A1> the type of the first argument
+     * @param <A2> the type of the second argument
+     * @param <A3> the type of the third argument
+     * @param <A4> the type of the fourth argument
+     * @param <A5> the type of the fifth argument
+     * @param <A6> the type of the sixth argument
+     * @param <A7> the type of the seventh argument
+     * @param <A8> the type of the eighth argument
+     */
+    <S extends Sender, A1, A2, A3, A4, A5, A6, A7, A8> void dispatch(
+            S sender,
+            A1 arg1,
+            A2 arg2,
+            A3 arg3,
+            A4 arg4,
+            A5 arg5,
+            A6 arg6,
+            A7 arg7,
+            A8 arg8,
+            ApiHandler.EightArg<S, A1, A2, A3, A4, A5, A6, A7, A8> handler);
+
+    /**
      * Called when this request is manually dispatched without calling {@code dispatch}.
      * <p>
      * The worker thread should immediately call {@link #executeHandler(DispatchedHandler)}.

--- a/drift-testlib/src/main/java/io/github/mikewacker/drift/testing/api/StubDispatcher.java
+++ b/drift-testlib/src/main/java/io/github/mikewacker/drift/testing/api/StubDispatcher.java
@@ -56,6 +56,46 @@ public final class StubDispatcher implements Dispatcher {
             S sender, A1 arg1, A2 arg2, A3 arg3, A4 arg4, ApiHandler.FourArg<S, A1, A2, A3, A4> handler) {}
 
     @Override
+    public <S extends Sender, A1, A2, A3, A4, A5> void dispatch(
+            S sender, A1 arg1, A2 arg2, A3 arg3, A4 arg4, A5 arg5, ApiHandler.FiveArg<S, A1, A2, A3, A4, A5> handler) {}
+
+    @Override
+    public <S extends Sender, A1, A2, A3, A4, A5, A6> void dispatch(
+            S sender,
+            A1 arg1,
+            A2 arg2,
+            A3 arg3,
+            A4 arg4,
+            A5 arg5,
+            A6 arg6,
+            ApiHandler.SixArg<S, A1, A2, A3, A4, A5, A6> handler) {}
+
+    @Override
+    public <S extends Sender, A1, A2, A3, A4, A5, A6, A7> void dispatch(
+            S sender,
+            A1 arg1,
+            A2 arg2,
+            A3 arg3,
+            A4 arg4,
+            A5 arg5,
+            A6 arg6,
+            A7 arg7,
+            ApiHandler.SevenArg<S, A1, A2, A3, A4, A5, A6, A7> handler) {}
+
+    @Override
+    public <S extends Sender, A1, A2, A3, A4, A5, A6, A7, A8> void dispatch(
+            S sender,
+            A1 arg1,
+            A2 arg2,
+            A3 arg3,
+            A4 arg4,
+            A5 arg5,
+            A6 arg6,
+            A7 arg7,
+            A8 arg8,
+            ApiHandler.EightArg<S, A1, A2, A3, A4, A5, A6, A7, A8> handler) {}
+
+    @Override
     public void dispatched() {}
 
     @Override

--- a/drift/src/main/java/io/github/mikewacker/drift/endpoint/UndertowDispatcher.java
+++ b/drift/src/main/java/io/github/mikewacker/drift/endpoint/UndertowDispatcher.java
@@ -41,29 +41,78 @@ final class UndertowDispatcher implements Dispatcher {
 
     @Override
     public <S extends Sender> void dispatch(S sender, ApiHandler.ZeroArg<S> handler) {
-        httpExchange.dispatch(ex -> handler.handleRequest(sender, this));
+        httpExchange.dispatch(he -> handler.handleRequest(sender, this));
     }
 
     @Override
     public <S extends Sender, A> void dispatch(S sender, A arg, ApiHandler.OneArg<S, A> handler) {
-        httpExchange.dispatch(ex -> handler.handleRequest(sender, arg, this));
+        httpExchange.dispatch(he -> handler.handleRequest(sender, arg, this));
     }
 
     @Override
     public <S extends Sender, A1, A2> void dispatch(S sender, A1 arg1, A2 arg2, ApiHandler.TwoArg<S, A1, A2> handler) {
-        httpExchange.dispatch(ex -> handler.handleRequest(sender, arg1, arg2, this));
+        httpExchange.dispatch(he -> handler.handleRequest(sender, arg1, arg2, this));
     }
 
     @Override
     public <S extends Sender, A1, A2, A3> void dispatch(
             S sender, A1 arg1, A2 arg2, A3 arg3, ApiHandler.ThreeArg<S, A1, A2, A3> handler) {
-        httpExchange.dispatch(ex -> handler.handleRequest(sender, arg1, arg2, arg3, this));
+        httpExchange.dispatch(he -> handler.handleRequest(sender, arg1, arg2, arg3, this));
     }
 
     @Override
     public <S extends Sender, A1, A2, A3, A4> void dispatch(
             S sender, A1 arg1, A2 arg2, A3 arg3, A4 arg4, ApiHandler.FourArg<S, A1, A2, A3, A4> handler) {
-        httpExchange.dispatch(ex -> handler.handleRequest(sender, arg1, arg2, arg3, arg4, this));
+        httpExchange.dispatch(he -> handler.handleRequest(sender, arg1, arg2, arg3, arg4, this));
+    }
+
+    @Override
+    public <S extends Sender, A1, A2, A3, A4, A5> void dispatch(
+            S sender, A1 arg1, A2 arg2, A3 arg3, A4 arg4, A5 arg5, ApiHandler.FiveArg<S, A1, A2, A3, A4, A5> handler) {
+        httpExchange.dispatch(he -> handler.handleRequest(sender, arg1, arg2, arg3, arg4, arg5, this));
+    }
+
+    @Override
+    public <S extends Sender, A1, A2, A3, A4, A5, A6> void dispatch(
+            S sender,
+            A1 arg1,
+            A2 arg2,
+            A3 arg3,
+            A4 arg4,
+            A5 arg5,
+            A6 arg6,
+            ApiHandler.SixArg<S, A1, A2, A3, A4, A5, A6> handler) {
+        httpExchange.dispatch(he -> handler.handleRequest(sender, arg1, arg2, arg3, arg4, arg5, arg6, this));
+    }
+
+    @Override
+    public <S extends Sender, A1, A2, A3, A4, A5, A6, A7> void dispatch(
+            S sender,
+            A1 arg1,
+            A2 arg2,
+            A3 arg3,
+            A4 arg4,
+            A5 arg5,
+            A6 arg6,
+            A7 arg7,
+            ApiHandler.SevenArg<S, A1, A2, A3, A4, A5, A6, A7> handler) {
+        httpExchange.dispatch(he -> handler.handleRequest(sender, arg1, arg2, arg3, arg4, arg5, arg6, arg7, this));
+    }
+
+    @Override
+    public <S extends Sender, A1, A2, A3, A4, A5, A6, A7, A8> void dispatch(
+            S sender,
+            A1 arg1,
+            A2 arg2,
+            A3 arg3,
+            A4 arg4,
+            A5 arg5,
+            A6 arg6,
+            A7 arg7,
+            A8 arg8,
+            ApiHandler.EightArg<S, A1, A2, A3, A4, A5, A6, A7, A8> handler) {
+        httpExchange.dispatch(
+                he -> handler.handleRequest(sender, arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, this));
     }
 
     @Override


### PR DESCRIPTION
still need to add corresponding logic to `backend`, `endpoint` packages