### PR TITLE
extend BackendDispatcher to pass along up to seven args

### DIFF
--- a/drift/src/main/java/io/github/mikewacker/drift/backend/BackendDispatcher.java
+++ b/drift/src/main/java/io/github/mikewacker/drift/backend/BackendDispatcher.java
@@ -114,5 +114,144 @@ public interface BackendDispatcher extends ApiClient {
                 ApiHandler.FourArg<S, A1, A2, A3, R> callback) {
             dispatch(sender, dispatcher, (s, response, d) -> callback.handleRequest(s, arg1, arg2, arg3, response, d));
         }
+
+        /**
+         * Sends this backend request asynchronously, passing four additional arguments along to the callback.
+         *
+         * @param sender the response sender for the frontend request, for when the response can be sent
+         * @param arg1 the first argument to dispatch
+         * @param arg2 the second argument to dispatch
+         * @param arg3 the third argument to dispatch
+         * @param arg4 the fourth argument to dispatch
+         * @param dispatcher the {@link Dispatcher} for the frontend request
+         * @param callback an {@link ApiHandler} that will process the backend response value
+         * @param <S> the interface for the response sender for the frontend request
+         * @param <A1> the type of the first argument
+         * @param <A2> the type of the second argument
+         * @param <A3> the type of the third argument
+         * @param <A4> the type of the fourth argument
+         */
+        default <S extends Sender, A1, A2, A3, A4> void dispatch(
+                S sender,
+                A1 arg1,
+                A2 arg2,
+                A3 arg3,
+                A4 arg4,
+                Dispatcher dispatcher,
+                ApiHandler.FiveArg<S, A1, A2, A3, A4, R> callback) {
+            dispatch(
+                    sender,
+                    dispatcher,
+                    (s, response, d) -> callback.handleRequest(s, arg1, arg2, arg3, arg4, response, d));
+        }
+
+        /**
+         * Sends this backend request asynchronously, passing five additional arguments along to the callback.
+         *
+         * @param sender the response sender for the frontend request, for when the response can be sent
+         * @param arg1 the first argument to dispatch
+         * @param arg2 the second argument to dispatch
+         * @param arg3 the third argument to dispatch
+         * @param arg4 the fourth argument to dispatch
+         * @param arg5 the fifth argument to dispatch
+         * @param dispatcher the {@link Dispatcher} for the frontend request
+         * @param callback an {@link ApiHandler} that will process the backend response value
+         * @param <S> the interface for the response sender for the frontend request
+         * @param <A1> the type of the first argument
+         * @param <A2> the type of the second argument
+         * @param <A3> the type of the third argument
+         * @param <A4> the type of the fourth argument
+         * @param <A5> the type of the fifth argument
+         */
+        default <S extends Sender, A1, A2, A3, A4, A5> void dispatch(
+                S sender,
+                A1 arg1,
+                A2 arg2,
+                A3 arg3,
+                A4 arg4,
+                A5 arg5,
+                Dispatcher dispatcher,
+                ApiHandler.SixArg<S, A1, A2, A3, A4, A5, R> callback) {
+            dispatch(
+                    sender,
+                    dispatcher,
+                    (s, response, d) -> callback.handleRequest(s, arg1, arg2, arg3, arg4, arg5, response, d));
+        }
+
+        /**
+         * Sends this backend request asynchronously, passing six additional arguments along to the callback.
+         *
+         * @param sender the response sender for the frontend request, for when the response can be sent
+         * @param arg1 the first argument to dispatch
+         * @param arg2 the second argument to dispatch
+         * @param arg3 the third argument to dispatch
+         * @param arg4 the fourth argument to dispatch
+         * @param arg5 the fifth argument to dispatch
+         * @param arg6 the sixth argument to dispatch
+         * @param dispatcher the {@link Dispatcher} for the frontend request
+         * @param callback an {@link ApiHandler} that will process the backend response value
+         * @param <S> the interface for the response sender for the frontend request
+         * @param <A1> the type of the first argument
+         * @param <A2> the type of the second argument
+         * @param <A3> the type of the third argument
+         * @param <A4> the type of the fourth argument
+         * @param <A5> the type of the fifth argument
+         * @param <A6> the type of the sixth argument
+         */
+        default <S extends Sender, A1, A2, A3, A4, A5, A6> void dispatch(
+                S sender,
+                A1 arg1,
+                A2 arg2,
+                A3 arg3,
+                A4 arg4,
+                A5 arg5,
+                A6 arg6,
+                Dispatcher dispatcher,
+                ApiHandler.SevenArg<S, A1, A2, A3, A4, A5, A6, R> callback) {
+            dispatch(
+                    sender,
+                    dispatcher,
+                    (s, response, d) -> callback.handleRequest(s, arg1, arg2, arg3, arg4, arg5, arg6, response, d));
+        }
+
+        /**
+         * Sends this backend request asynchronously, passing seven additional arguments along to the callback.
+         *
+         * @param sender the response sender for the frontend request, for when the response can be sent
+         * @param arg1 the first argument to dispatch
+         * @param arg2 the second argument to dispatch
+         * @param arg3 the third argument to dispatch
+         * @param arg4 the fourth argument to dispatch
+         * @param arg5 the fifth argument to dispatch
+         * @param arg6 the sixth argument to dispatch
+         * @param arg7 the seventh argument to dispatch
+         * @param dispatcher the {@link Dispatcher} for the frontend request
+         * @param callback an {@link ApiHandler} that will process the backend response value
+         * @param <S> the interface for the response sender for the frontend request
+         * @param <A1> the type of the first argument
+         * @param <A2> the type of the second argument
+         * @param <A3> the type of the third argument
+         * @param <A4> the type of the fourth argument
+         * @param <A5> the type of the fifth argument
+         * @param <A6> the type of the sixth argument
+         * @param <A7> the type of the seventh argument
+         */
+        default <S extends Sender, A1, A2, A3, A4, A5, A6, A7> void dispatch(
+                S sender,
+                A1 arg1,
+                A2 arg2,
+                A3 arg3,
+                A4 arg4,
+                A5 arg5,
+                A6 arg6,
+                A7 arg7,
+                Dispatcher dispatcher,
+                ApiHandler.EightArg<S, A1, A2, A3, A4, A5, A6, A7, R> callback) {
+            dispatch(
+                    sender,
+                    dispatcher,
+                    (s, response, d) ->
+                            callback.handleRequest(s, arg1, arg2, arg3, arg4, arg5, arg6, arg7, response, d));
+        }
     }
 }


### PR DESCRIPTION
(need to reserve one arg for the backend response)