### PR TITLE
add route to adapted API handler

### DIFF
--- a/drift/src/main/java/io/github/mikewacker/drift/endpoint/AdaptedApiHandler.java
+++ b/drift/src/main/java/io/github/mikewacker/drift/endpoint/AdaptedApiHandler.java
@@ -1,67 +1,124 @@
 package io.github.mikewacker.drift.endpoint;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.mikewacker.drift.api.ApiHandler;
+import io.github.mikewacker.drift.api.HttpOptional;
 import io.github.mikewacker.drift.api.Sender;
+import java.util.List;
 
 /**
- * An HTTP handler for the underlying server that invokes an API handler.
+ * An HTTP handler for the underlying server that invokes an API handler, using JSON as the wire format.
  *
  * @param <E> the type of the underlying HTTP exchange
  */
 public interface AdaptedApiHandler<E> {
 
     /**
-     * Handles the underlying HTTP request by invoking an API handler.
+     * Gets the HTTP method for this API.
      *
-     * @param exchange the underlying HTTP exchange
-     * @throws Exception for any exception that this handler may throw
+     * @return an HTTP method
      */
-    void handleRequest(E exchange) throws Exception;
+    HttpMethod getMethod();
 
     /**
-     * Builder for an HTTP handler for the underlying server that invokes an API handler.
-     * The API handler has zero or more arguments.
+     * Gets the relative URL path for this API, split into segments using {@code '/'} as the delimiter.
+     *
+     * @return a list of path segments
+     */
+    List<String> getRelativePathSegments();
+
+    /**
+     * Handles the underlying HTTP request by invoking an API handler.
+     *
+     * @param httpExchange the underlying HTTP exchange
+     * @throws Exception for any exception that this handler may throw
+     */
+    void handleRequest(E httpExchange) throws Exception;
+
+    /**
+     * Builder for an HTTP handler that can set the route: the HTTP method and the relative path.
+     *
+     * @param <E> the type of the underlying HTTP exchange
+     * @param <EH> the type of the HTTP handler for the underlying server
+     */
+    interface RouteStageBuilder<E, EH extends AdaptedApiHandler<E>> {
+
+        /**
+         * Sets the route.
+         *
+         * @param method the HTTP method of the route
+         * @param relativePath the relative URL path of the route
+         * @return a builder at the response stage
+         */
+        ResponseStageBuilder<E, EH> route(HttpMethod method, String relativePath);
+    }
+
+    /**
+     * Builder for an HTTP handler that can set the type of the response.
+     *
+     * @param <E> the type of the underlying HTTP exchange
+     * @param <EH> the type of the HTTP handler for the underlying server
+     */
+    interface ResponseStageBuilder<E, EH extends AdaptedApiHandler<E>> {
+
+        /**
+         * Sets the type of the response to only an HTTP status code.
+         *
+         * @return a builder at the zero arguments stage
+         */
+        ZeroArgStageBuilder<E, EH, Sender.StatusCode> statusCodeResponse();
+
+        /**
+         * Sets the type of the response to an {@link HttpOptional} value that is deserialized from JSON.
+         *
+         * @param responseValueTypeRef a {@link TypeReference} for the response value
+         * @return a builder at the zero arguments stage
+         * @param <V> the type of the response value
+         */
+        <V> ZeroArgStageBuilder<E, EH, Sender.Value<V>> jsonResponse(TypeReference<V> responseValueTypeRef);
+    }
+
+    /**
+     * Builder for an HTTP handler that can set the API handler with zero arguments or add an argument.
      *
      * @param <E> the type of the underlying HTTP exchange
      * @param <EH> the type of the HTTP handler for the underlying server
      * @param <S> the type of the response sender for the API handler
      */
-    interface ZeroArgBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender>
-            extends ArgBuilder<E, EH, ApiHandler.ZeroArg<S>> {
+    interface ZeroArgStageBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender>
+            extends ArgStageBuilder<E, EH, ApiHandler.ZeroArg<S>> {
 
         @Override
-        default <A1> OneArgBuilder<E, EH, S, A1> addArg(ArgExtractor<E, A1> arg1Extractor) {
-            return addArg(arg1Extractor.async());
+        default <A1> OneArgStageBuilder<E, EH, S, A1> arg(ArgExtractor<E, A1> arg1Extractor) {
+            return arg(arg1Extractor.async());
         }
 
         @Override
-        <A1> OneArgBuilder<E, EH, S, A1> addArg(ArgExtractor.Async<E, A1> arg1Extractor);
+        <A1> OneArgStageBuilder<E, EH, S, A1> arg(ArgExtractor.Async<E, A1> arg1Extractor);
     }
 
     /**
-     * Builder for an HTTP handler for the underlying server that invokes an API handler.
-     * The API handler has one or more arguments.
+     * Builder for an HTTP handler that can set the API handler with one argument or add an argument.
      *
      * @param <E> the type of the underlying HTTP exchange
      * @param <EH> the type of the HTTP handler for the underlying server
      * @param <S> the type of the response sender for the API handler
      * @param <A1> the type of the first argument for the API handler
      */
-    interface OneArgBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender, A1>
-            extends ArgBuilder<E, EH, ApiHandler.OneArg<S, A1>> {
+    interface OneArgStageBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender, A1>
+            extends ArgStageBuilder<E, EH, ApiHandler.OneArg<S, A1>> {
 
         @Override
-        default <A2> TwoArgBuilder<E, EH, S, A1, A2> addArg(ArgExtractor<E, A2> arg2Extractor) {
-            return addArg(arg2Extractor.async());
+        default <A2> TwoArgStageBuilder<E, EH, S, A1, A2> arg(ArgExtractor<E, A2> arg2Extractor) {
+            return arg(arg2Extractor.async());
         }
 
         @Override
-        <A2> TwoArgBuilder<E, EH, S, A1, A2> addArg(ArgExtractor.Async<E, A2> arg2Extractor);
+        <A2> TwoArgStageBuilder<E, EH, S, A1, A2> arg(ArgExtractor.Async<E, A2> arg2Extractor);
     }
 
     /**
-     * Builder for an HTTP handler for the underlying server that invokes an API handler.
-     * The API handler has two or more arguments.
+     * Builder for an HTTP handler that can set the API handler with two arguments or add an argument.
      *
      * @param <E> the type of the underlying HTTP exchange
      * @param <EH> the type of the HTTP handler for the underlying server
@@ -69,21 +126,20 @@ public interface AdaptedApiHandler<E> {
      * @param <A1> the type of the first argument for the API handler
      * @param <A2> the type of the second argument for the API handler
      */
-    interface TwoArgBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender, A1, A2>
-            extends ArgBuilder<E, EH, ApiHandler.TwoArg<S, A1, A2>> {
+    interface TwoArgStageBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender, A1, A2>
+            extends ArgStageBuilder<E, EH, ApiHandler.TwoArg<S, A1, A2>> {
 
         @Override
-        default <A3> ThreeArgBuilder<E, EH, S, A1, A2, A3> addArg(ArgExtractor<E, A3> arg3Extractor) {
-            return addArg(arg3Extractor.async());
+        default <A3> ThreeArgStageBuilder<E, EH, S, A1, A2, A3> arg(ArgExtractor<E, A3> arg3Extractor) {
+            return arg(arg3Extractor.async());
         }
 
         @Override
-        <A3> ThreeArgBuilder<E, EH, S, A1, A2, A3> addArg(ArgExtractor.Async<E, A3> arg3Extractor);
+        <A3> ThreeArgStageBuilder<E, EH, S, A1, A2, A3> arg(ArgExtractor.Async<E, A3> arg3Extractor);
     }
 
     /**
-     * Builder for an HTTP handler for the underlying server that invokes an API handler.
-     * The API handler has three or more arguments.
+     * Builder for an HTTP handler that can set the API handler with three arguments or add an argument.
      *
      * @param <E> the type of the underlying HTTP exchange
      * @param <EH> the type of the HTTP handler for the underlying server
@@ -92,21 +148,20 @@ public interface AdaptedApiHandler<E> {
      * @param <A2> the type of the second argument for the API handler
      * @param <A3> the type of the third argument for the API handler
      */
-    interface ThreeArgBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender, A1, A2, A3>
-            extends ArgBuilder<E, EH, ApiHandler.ThreeArg<S, A1, A2, A3>> {
+    interface ThreeArgStageBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender, A1, A2, A3>
+            extends ArgStageBuilder<E, EH, ApiHandler.ThreeArg<S, A1, A2, A3>> {
 
         @Override
-        default <A4> FourArgBuilder<E, EH, S, A1, A2, A3, A4> addArg(ArgExtractor<E, A4> arg4Extractor) {
-            return addArg(arg4Extractor.async());
+        default <A4> FourArgStageBuilder<E, EH, S, A1, A2, A3, A4> arg(ArgExtractor<E, A4> arg4Extractor) {
+            return arg(arg4Extractor.async());
         }
 
         @Override
-        <A4> FourArgBuilder<E, EH, S, A1, A2, A3, A4> addArg(ArgExtractor.Async<E, A4> arg4Extractor);
+        <A4> FourArgStageBuilder<E, EH, S, A1, A2, A3, A4> arg(ArgExtractor.Async<E, A4> arg4Extractor);
     }
 
     /**
-     * Builder for an HTTP handler for the underlying server that invokes an API handler.
-     * The API handler has four arguments.
+     * Builder for an HTTP handler that can set the API handler with four arguments or add an argument.
      *
      * @param <E> the type of the underlying HTTP exchange
      * @param <EH> the type of the HTTP handler for the underlying server
@@ -116,21 +171,20 @@ public interface AdaptedApiHandler<E> {
      * @param <A3> the type of the third argument for the API handler
      * @param <A4> the type of the fourth argument for the API handler
      */
-    interface FourArgBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender, A1, A2, A3, A4>
-            extends ArgBuilder<E, EH, ApiHandler.FourArg<S, A1, A2, A3, A4>> {
+    interface FourArgStageBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender, A1, A2, A3, A4>
+            extends ArgStageBuilder<E, EH, ApiHandler.FourArg<S, A1, A2, A3, A4>> {
 
         @Override
-        default <A5> FiveArgBuilder<E, EH, S, A1, A2, A3, A4, A5> addArg(ArgExtractor<E, A5> arg5Extractor) {
-            return addArg(arg5Extractor.async());
+        default <A5> FiveArgStageBuilder<E, EH, S, A1, A2, A3, A4, A5> arg(ArgExtractor<E, A5> arg5Extractor) {
+            return arg(arg5Extractor.async());
         }
 
         @Override
-        <A5> FiveArgBuilder<E, EH, S, A1, A2, A3, A4, A5> addArg(ArgExtractor.Async<E, A5> arg5Extractor);
+        <A5> FiveArgStageBuilder<E, EH, S, A1, A2, A3, A4, A5> arg(ArgExtractor.Async<E, A5> arg5Extractor);
     }
 
     /**
-     * Builder for an HTTP handler for the underlying server that invokes an API handler.
-     * The API handler has five arguments.
+     * Builder for an HTTP handler that can set the API handler with five arguments or add an argument.
      *
      * @param <E> the type of the underlying HTTP exchange
      * @param <EH> the type of the HTTP handler for the underlying server
@@ -141,21 +195,20 @@ public interface AdaptedApiHandler<E> {
      * @param <A4> the type of the fourth argument for the API handler
      * @param <A5> the type of the fifth argument for the API handler
      */
-    interface FiveArgBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender, A1, A2, A3, A4, A5>
-            extends ArgBuilder<E, EH, ApiHandler.FiveArg<S, A1, A2, A3, A4, A5>> {
+    interface FiveArgStageBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender, A1, A2, A3, A4, A5>
+            extends ArgStageBuilder<E, EH, ApiHandler.FiveArg<S, A1, A2, A3, A4, A5>> {
 
         @Override
-        default <A6> SixArgBuilder<E, EH, S, A1, A2, A3, A4, A5, A6> addArg(ArgExtractor<E, A6> arg6Extractor) {
-            return addArg(arg6Extractor.async());
+        default <A6> SixArgStageBuilder<E, EH, S, A1, A2, A3, A4, A5, A6> arg(ArgExtractor<E, A6> arg6Extractor) {
+            return arg(arg6Extractor.async());
         }
 
         @Override
-        <A6> SixArgBuilder<E, EH, S, A1, A2, A3, A4, A5, A6> addArg(ArgExtractor.Async<E, A6> arg6Extractor);
+        <A6> SixArgStageBuilder<E, EH, S, A1, A2, A3, A4, A5, A6> arg(ArgExtractor.Async<E, A6> arg6Extractor);
     }
 
     /**
-     * Builder for an HTTP handler for the underlying server that invokes an API handler.
-     * The API handler has six arguments.
+     * Builder for an HTTP handler that can set the API handler with six arguments or add an argument.
      *
      * @param <E> the type of the underlying HTTP exchange
      * @param <EH> the type of the HTTP handler for the underlying server
@@ -167,21 +220,20 @@ public interface AdaptedApiHandler<E> {
      * @param <A5> the type of the fifth argument for the API handler
      * @param <A6> the type of the sixth argument for the API handler
      */
-    interface SixArgBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender, A1, A2, A3, A4, A5, A6>
-            extends ArgBuilder<E, EH, ApiHandler.SixArg<S, A1, A2, A3, A4, A5, A6>> {
+    interface SixArgStageBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender, A1, A2, A3, A4, A5, A6>
+            extends ArgStageBuilder<E, EH, ApiHandler.SixArg<S, A1, A2, A3, A4, A5, A6>> {
 
         @Override
-        default <A7> SevenArgBuilder<E, EH, S, A1, A2, A3, A4, A5, A6, A7> addArg(ArgExtractor<E, A7> arg7Extractor) {
-            return addArg(arg7Extractor.async());
+        default <A7> SevenArgStageBuilder<E, EH, S, A1, A2, A3, A4, A5, A6, A7> arg(ArgExtractor<E, A7> arg7Extractor) {
+            return arg(arg7Extractor.async());
         }
 
         @Override
-        <A7> SevenArgBuilder<E, EH, S, A1, A2, A3, A4, A5, A6, A7> addArg(ArgExtractor.Async<E, A7> arg7Extractor);
+        <A7> SevenArgStageBuilder<E, EH, S, A1, A2, A3, A4, A5, A6, A7> arg(ArgExtractor.Async<E, A7> arg7Extractor);
     }
 
     /**
-     * Builder for an HTTP handler for the underlying server that invokes an API handler.
-     * The API handler has seven arguments.
+     * Builder for an HTTP handler that can set the API handler with seven arguments or add an argument.
      *
      * @param <E> the type of the underlying HTTP exchange
      * @param <EH> the type of the HTTP handler for the underlying server
@@ -194,22 +246,22 @@ public interface AdaptedApiHandler<E> {
      * @param <A6> the type of the sixth argument for the API handler
      * @param <A7> the type of the seventh argument for the API handler
      */
-    interface SevenArgBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender, A1, A2, A3, A4, A5, A6, A7>
-            extends ArgBuilder<E, EH, ApiHandler.SevenArg<S, A1, A2, A3, A4, A5, A6, A7>> {
+    interface SevenArgStageBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender, A1, A2, A3, A4, A5, A6, A7>
+            extends ArgStageBuilder<E, EH, ApiHandler.SevenArg<S, A1, A2, A3, A4, A5, A6, A7>> {
 
         @Override
-        default <A8> EightArgBuilder<E, EH, S, A1, A2, A3, A4, A5, A6, A7, A8> addArg(
+        default <A8> EightArgStageBuilder<E, EH, S, A1, A2, A3, A4, A5, A6, A7, A8> arg(
                 ArgExtractor<E, A8> arg8Extractor) {
-            return addArg(arg8Extractor.async());
+            return arg(arg8Extractor.async());
         }
 
         @Override
-        <A8> EightArgBuilder<E, EH, S, A1, A2, A3, A4, A5, A6, A7, A8> addArg(ArgExtractor.Async<E, A8> arg8Extractor);
+        <A8> EightArgStageBuilder<E, EH, S, A1, A2, A3, A4, A5, A6, A7, A8> arg(
+                ArgExtractor.Async<E, A8> arg8Extractor);
     }
 
     /**
-     * Builder for an HTTP handler for the underlying server that invokes an API handler.
-     * The API handler has eight arguments.
+     * Builder for an HTTP handler that can set the API handler with eight arguments or add an argument.
      *
      * @param <E> the type of the underlying HTTP exchange
      * @param <EH> the type of the HTTP handler for the underlying server
@@ -223,55 +275,71 @@ public interface AdaptedApiHandler<E> {
      * @param <A7> the type of the seventh argument for the API handler
      * @param <A8> the type of the eighth argument for the API handler
      */
-    interface EightArgBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender, A1, A2, A3, A4, A5, A6, A7, A8>
-            extends Builder<E, EH, ApiHandler.EightArg<S, A1, A2, A3, A4, A5, A6, A7, A8>> {}
+    interface EightArgStageBuilder<E, EH extends AdaptedApiHandler<E>, S extends Sender, A1, A2, A3, A4, A5, A6, A7, A8>
+            extends ApiHandlerStageBuilder<E, EH, ApiHandler.EightArg<S, A1, A2, A3, A4, A5, A6, A7, A8>> {}
 
     /**
-     * Builder for an HTTP handler for the underlying server that invokes an API handler.
+     * Builder for an HTTP handler that can set the API handler.
      *
      * @param <E> the type of the underlying HTTP exchange
      * @param <EH> the type of the HTTP handler for the underlying server
      * @param <AH> the type of the API handler
      */
-    interface Builder<E, EH extends AdaptedApiHandler<E>, AH extends ApiHandler> {
+    interface ApiHandlerStageBuilder<E, EH extends AdaptedApiHandler<E>, AH extends ApiHandler> {
 
         /**
-         * Builds an HTTP handler for the underlying server that invokes an API handler.
+         * Sets the API handler.
          *
          * @param apiHandler the API handler
-         * @return an HTTP handler for the underlying server that invokes the API handler
+         * @return a builder at the final stage
          */
-        EH build(AH apiHandler);
+        FinalStageBuilder<E, EH> apiHandler(AH apiHandler);
     }
 
     /**
-     * Builder for an HTTP handler for the underlying server that invokes an API handler.
-     * It can add an argument to the API handler.
+     * Builder for an HTTP handler that can set the API handler or add an argument.
      * <p>
-     * Subtypes will override the return type.
+     * Subtypes will override the return type, which is the next stage of the builder.
      *
      * @param <E> the type of the underlying HTTP exchange
      * @param <EH> the type of the HTTP handler for the underlying server
      * @param <AH> the type of the API handler
      */
-    interface ArgBuilder<E, EH extends AdaptedApiHandler<E>, AH extends ApiHandler> extends Builder<E, EH, AH> {
+    interface ArgStageBuilder<E, EH extends AdaptedApiHandler<E>, AH extends ApiHandler>
+            extends ApiHandlerStageBuilder<E, EH, AH> {
 
         /**
          * Adds an argument to the API handler. The argument will be extracted from the underlying HTTP request.
          *
          * @param argExtractor the extractor that gets the argument from the underlying HTTP request
-         * @return a builder with an additional argument for the API handler
+         * @return a builder at the stage with an additional argument
          * @param <A> the type of the argument for the API handler
          */
-        <A> Object addArg(ArgExtractor<E, A> argExtractor);
+        <A> Object arg(ArgExtractor<E, A> argExtractor);
 
         /**
          * Adds an argument to the API handler. The argument will be extracted from the underlying HTTP request.
          *
          * @param argExtractor the extractor that gets the argument from the underlying HTTP request
-         * @return a builder with an additional argument for the API handler
+         * @return a builder at the stage with an additional argument
          * @param <A> the type of the argument for the API handler
          */
-        <A> Object addArg(ArgExtractor.Async<E, A> argExtractor);
+        <A> Object arg(ArgExtractor.Async<E, A> argExtractor);
+    }
+
+    /**
+     * Builder for an HTTP handler that can build the HTTP handler.
+     *
+     * @param <E> the type of the underlying HTTP exchange
+     * @param <EH> the type of the HTTP handler for the underlying server
+     */
+    interface FinalStageBuilder<E, EH extends AdaptedApiHandler<E>> {
+
+        /**
+         * Builds the HTTP handler.
+         *
+         * @return the HTTP handler
+         */
+        EH build();
     }
 }

--- a/drift/src/test/java/io/github/mikewacker/drift/backend/ProxyEndpoint.java
+++ b/drift/src/test/java/io/github/mikewacker/drift/backend/ProxyEndpoint.java
@@ -12,9 +12,16 @@ final class ProxyEndpoint {
     public static HttpHandler create() {
         ProxyApi proxyApi = ProxyService.create();
 
-        HttpHandler statusCodeHandler = UndertowJsonApiHandler.builder().build(proxyApi::proxyStatusCode);
-        HttpHandler textHandler =
-                UndertowJsonApiHandler.builder(new TypeReference<String>() {}).build(proxyApi::proxyText);
+        HttpHandler statusCodeHandler = UndertowJsonApiHandler.builder()
+                .route(HttpMethod.GET, "/status-code")
+                .statusCodeResponse()
+                .apiHandler(proxyApi::proxyStatusCode)
+                .build();
+        HttpHandler textHandler = UndertowJsonApiHandler.builder()
+                .route(HttpMethod.GET, "/text")
+                .jsonResponse(new TypeReference<String>() {})
+                .apiHandler(proxyApi::proxyText)
+                .build();
 
         return UndertowRouter.builder()
                 .addRoute(HttpMethod.GET, "/status-code", statusCodeHandler)

--- a/drift/src/test/java/io/github/mikewacker/drift/endpoint/GenericAdaptedApiHandlerTest.java
+++ b/drift/src/test/java/io/github/mikewacker/drift/endpoint/GenericAdaptedApiHandlerTest.java
@@ -2,28 +2,31 @@ package io.github.mikewacker.drift.endpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.github.mikewacker.drift.api.Dispatcher;
+import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.mikewacker.drift.api.HttpOptional;
 import io.github.mikewacker.drift.api.Sender;
 import io.github.mikewacker.drift.testing.api.FakeSender;
 import io.github.mikewacker.drift.testing.api.StubDispatcher;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public final class GenericAdaptedApiHandlerTest {
 
-    private static FakeSender.Value<Integer> sender;
-    private static Dispatcher dispatcher;
+    private static FakeSender.Value<Object> sender;
 
     @BeforeEach
-    public void createSenderAndDispatcher() {
-        sender = FakeSender.Value.create();
-        dispatcher = StubDispatcher.get();
+    public void reset() {
+        sender = null;
     }
 
     @Test
     public void handleHttpRequest_ZeroArgApiRequest() throws Exception {
-        StubHttpHandler httpHandler = StubHttpHandler.builder().build(Adder::add0);
+        StubHttpHandler httpHandler = StubHttpHandler.builder()
+                .route(HttpMethod.GET, "/some/path")
+                .jsonResponse(new TypeReference<Integer>() {})
+                .apiHandler(Adder::add0)
+                .build();
         StubHttpExchange httpExchange = StubHttpExchange.create(null, null, null, null, null, null, null, null);
         httpHandler.handleRequest(httpExchange);
         assertThat(sender.tryGet()).hasValue(HttpOptional.of(0));
@@ -31,8 +34,12 @@ public final class GenericAdaptedApiHandlerTest {
 
     @Test
     public void handleHttpRequest_OneArgApiRequest() throws Exception {
-        StubHttpHandler httpHandler =
-                StubHttpHandler.builder().addArg(StubHttpExchange::maybeAddend1).build(Adder::add1);
+        StubHttpHandler httpHandler = StubHttpHandler.builder()
+                .route(HttpMethod.GET, "/some/path")
+                .jsonResponse(new TypeReference<Integer>() {})
+                .arg(StubHttpExchange::maybeAddend1)
+                .apiHandler(Adder::add1)
+                .build();
         StubHttpExchange httpExchange = StubHttpExchange.create("1", null, null, null, null, null, null, null);
         httpHandler.handleRequest(httpExchange);
         assertThat(sender.tryGet()).hasValue(HttpOptional.of(1));
@@ -41,9 +48,12 @@ public final class GenericAdaptedApiHandlerTest {
     @Test
     public void handleHttpRequest_TwoArgApiRequest() throws Exception {
         StubHttpHandler httpHandler = StubHttpHandler.builder()
-                .addArg(StubHttpExchange::maybeAddend1)
-                .addArg(StubHttpExchange::maybeAddend2)
-                .build(Adder::add2);
+                .route(HttpMethod.GET, "/some/path")
+                .jsonResponse(new TypeReference<Integer>() {})
+                .arg(StubHttpExchange::maybeAddend1)
+                .arg(StubHttpExchange::maybeAddend2)
+                .apiHandler(Adder::add2)
+                .build();
         StubHttpExchange httpExchange = StubHttpExchange.create("1", "2", null, null, null, null, null, null);
         httpHandler.handleRequest(httpExchange);
         assertThat(sender.tryGet()).hasValue(HttpOptional.of(3));
@@ -52,10 +62,13 @@ public final class GenericAdaptedApiHandlerTest {
     @Test
     public void handleHttpRequest_ThreeArgApiRequest() throws Exception {
         StubHttpHandler httpHandler = StubHttpHandler.builder()
-                .addArg(StubHttpExchange::maybeAddend1)
-                .addArg(StubHttpExchange::maybeAddend2)
-                .addArg(StubHttpExchange::maybeAddend3)
-                .build(Adder::add3);
+                .route(HttpMethod.GET, "/some/path")
+                .jsonResponse(new TypeReference<Integer>() {})
+                .arg(StubHttpExchange::maybeAddend1)
+                .arg(StubHttpExchange::maybeAddend2)
+                .arg(StubHttpExchange::maybeAddend3)
+                .apiHandler(Adder::add3)
+                .build();
         StubHttpExchange httpExchange = StubHttpExchange.create("1", "2", "3", null, null, null, null, null);
         httpHandler.handleRequest(httpExchange);
         assertThat(sender.tryGet()).hasValue(HttpOptional.of(6));
@@ -64,11 +77,14 @@ public final class GenericAdaptedApiHandlerTest {
     @Test
     public void handleHttpRequest_FourArgApiRequest() throws Exception {
         StubHttpHandler httpHandler = StubHttpHandler.builder()
-                .addArg(StubHttpExchange::maybeAddend1)
-                .addArg(StubHttpExchange::maybeAddend2)
-                .addArg(StubHttpExchange::maybeAddend3)
-                .addArg(StubHttpExchange::maybeAddend4)
-                .build(Adder::add4);
+                .route(HttpMethod.GET, "/some/path")
+                .jsonResponse(new TypeReference<Integer>() {})
+                .arg(StubHttpExchange::maybeAddend1)
+                .arg(StubHttpExchange::maybeAddend2)
+                .arg(StubHttpExchange::maybeAddend3)
+                .arg(StubHttpExchange::maybeAddend4)
+                .apiHandler(Adder::add4)
+                .build();
         StubHttpExchange httpExchange = StubHttpExchange.create("1", "2", "3", "4", null, null, null, null);
         httpHandler.handleRequest(httpExchange);
         assertThat(sender.tryGet()).hasValue(HttpOptional.of(10));
@@ -77,12 +93,15 @@ public final class GenericAdaptedApiHandlerTest {
     @Test
     public void handleHttpRequest_FiveArgApiRequest() throws Exception {
         StubHttpHandler httpHandler = StubHttpHandler.builder()
-                .addArg(StubHttpExchange::maybeAddend1)
-                .addArg(StubHttpExchange::maybeAddend2)
-                .addArg(StubHttpExchange::maybeAddend3)
-                .addArg(StubHttpExchange::maybeAddend4)
-                .addArg(StubHttpExchange::maybeAddend5)
-                .build(Adder::add5);
+                .route(HttpMethod.GET, "/some/path")
+                .jsonResponse(new TypeReference<Integer>() {})
+                .arg(StubHttpExchange::maybeAddend1)
+                .arg(StubHttpExchange::maybeAddend2)
+                .arg(StubHttpExchange::maybeAddend3)
+                .arg(StubHttpExchange::maybeAddend4)
+                .arg(StubHttpExchange::maybeAddend5)
+                .apiHandler(Adder::add5)
+                .build();
         StubHttpExchange httpExchange = StubHttpExchange.create("1", "2", "3", "4", "5", null, null, null);
         httpHandler.handleRequest(httpExchange);
         assertThat(sender.tryGet()).hasValue(HttpOptional.of(15));
@@ -91,13 +110,16 @@ public final class GenericAdaptedApiHandlerTest {
     @Test
     public void handleHttpRequest_SixArgApiRequest() throws Exception {
         StubHttpHandler httpHandler = StubHttpHandler.builder()
-                .addArg(StubHttpExchange::maybeAddend1)
-                .addArg(StubHttpExchange::maybeAddend2)
-                .addArg(StubHttpExchange::maybeAddend3)
-                .addArg(StubHttpExchange::maybeAddend4)
-                .addArg(StubHttpExchange::maybeAddend5)
-                .addArg(StubHttpExchange::maybeAddend6)
-                .build(Adder::add6);
+                .route(HttpMethod.GET, "/some/path")
+                .jsonResponse(new TypeReference<Integer>() {})
+                .arg(StubHttpExchange::maybeAddend1)
+                .arg(StubHttpExchange::maybeAddend2)
+                .arg(StubHttpExchange::maybeAddend3)
+                .arg(StubHttpExchange::maybeAddend4)
+                .arg(StubHttpExchange::maybeAddend5)
+                .arg(StubHttpExchange::maybeAddend6)
+                .apiHandler(Adder::add6)
+                .build();
         StubHttpExchange httpExchange = StubHttpExchange.create("1", "2", "3", "4", "5", "6", null, null);
         httpHandler.handleRequest(httpExchange);
         assertThat(sender.tryGet()).hasValue(HttpOptional.of(21));
@@ -106,14 +128,17 @@ public final class GenericAdaptedApiHandlerTest {
     @Test
     public void handleHttpRequest_SevenArgApiRequest() throws Exception {
         StubHttpHandler httpHandler = StubHttpHandler.builder()
-                .addArg(StubHttpExchange::maybeAddend1)
-                .addArg(StubHttpExchange::maybeAddend2)
-                .addArg(StubHttpExchange::maybeAddend3)
-                .addArg(StubHttpExchange::maybeAddend4)
-                .addArg(StubHttpExchange::maybeAddend5)
-                .addArg(StubHttpExchange::maybeAddend6)
-                .addArg(StubHttpExchange::maybeAddend7)
-                .build(Adder::add7);
+                .route(HttpMethod.GET, "/some/path")
+                .jsonResponse(new TypeReference<Integer>() {})
+                .arg(StubHttpExchange::maybeAddend1)
+                .arg(StubHttpExchange::maybeAddend2)
+                .arg(StubHttpExchange::maybeAddend3)
+                .arg(StubHttpExchange::maybeAddend4)
+                .arg(StubHttpExchange::maybeAddend5)
+                .arg(StubHttpExchange::maybeAddend6)
+                .arg(StubHttpExchange::maybeAddend7)
+                .apiHandler(Adder::add7)
+                .build();
         StubHttpExchange httpExchange = StubHttpExchange.create("1", "2", "3", "4", "5", "6", "7", null);
         httpHandler.handleRequest(httpExchange);
         assertThat(sender.tryGet()).hasValue(HttpOptional.of(28));
@@ -122,15 +147,18 @@ public final class GenericAdaptedApiHandlerTest {
     @Test
     public void handleHttpRequest_EightArgApiRequest() throws Exception {
         StubHttpHandler httpHandler = StubHttpHandler.builder()
-                .addArg(StubHttpExchange::maybeAddend1)
-                .addArg(StubHttpExchange::maybeAddend2)
-                .addArg(StubHttpExchange::maybeAddend3)
-                .addArg(StubHttpExchange::maybeAddend4)
-                .addArg(StubHttpExchange::maybeAddend5)
-                .addArg(StubHttpExchange::maybeAddend6)
-                .addArg(StubHttpExchange::maybeAddend7)
-                .addArg(StubHttpExchange::maybeAddend8)
-                .build(Adder::add8);
+                .route(HttpMethod.GET, "/some/path")
+                .jsonResponse(new TypeReference<Integer>() {})
+                .arg(StubHttpExchange::maybeAddend1)
+                .arg(StubHttpExchange::maybeAddend2)
+                .arg(StubHttpExchange::maybeAddend3)
+                .arg(StubHttpExchange::maybeAddend4)
+                .arg(StubHttpExchange::maybeAddend5)
+                .arg(StubHttpExchange::maybeAddend6)
+                .arg(StubHttpExchange::maybeAddend7)
+                .arg(StubHttpExchange::maybeAddend8)
+                .apiHandler(Adder::add8)
+                .build();
         StubHttpExchange httpExchange = StubHttpExchange.create("1", "2", "3", "4", "5", "6", "7", "8");
         httpHandler.handleRequest(httpExchange);
         assertThat(sender.tryGet()).hasValue(HttpOptional.of(36));
@@ -138,11 +166,26 @@ public final class GenericAdaptedApiHandlerTest {
 
     @Test
     public void handleHttpRequest_ArgExtractorFails() throws Exception {
-        StubHttpHandler httpHandler =
-                StubHttpHandler.builder().addArg(StubHttpExchange::maybeAddend1).build(Adder::add1);
+        StubHttpHandler httpHandler = StubHttpHandler.builder()
+                .route(HttpMethod.GET, "/some/path")
+                .jsonResponse(new TypeReference<Integer>() {})
+                .arg(StubHttpExchange::maybeAddend1)
+                .apiHandler(Adder::add1)
+                .build();
         StubHttpExchange httpExchange = StubHttpExchange.create("a", null, null, null, null, null, null, null);
         httpHandler.handleRequest(httpExchange);
         assertThat(sender.tryGet()).hasValue(HttpOptional.empty(400));
+    }
+
+    @Test
+    public void getRoute() {
+        StubHttpHandler httpHandler = StubHttpHandler.builder()
+                .route(HttpMethod.GET, "/some/path")
+                .jsonResponse(new TypeReference<Integer>() {})
+                .apiHandler(Adder::add0)
+                .build();
+        assertThat(httpHandler.getMethod()).isEqualTo(HttpMethod.GET);
+        assertThat(httpHandler.getRelativePathSegments()).containsExactly("some", "path");
     }
 
     /** Stub HTTP handler. */
@@ -150,9 +193,18 @@ public final class GenericAdaptedApiHandlerTest {
 
         private final AdaptedApiHandler<StubHttpExchange> delegate;
 
-        public static ZeroArgBuilder<StubHttpExchange, StubHttpHandler, Sender.Value<Integer>> builder() {
-            return GenericAdaptedApiHandler.builder(
-                    StubHttpExchange::sender, StubHttpExchange::dispatcher, StubHttpHandler::new);
+        public static RouteStageBuilder<StubHttpExchange, StubHttpHandler> builder() {
+            return new StubPreArgStageBuilder();
+        }
+
+        @Override
+        public HttpMethod getMethod() {
+            return delegate.getMethod();
+        }
+
+        @Override
+        public List<String> getRelativePathSegments() {
+            return delegate.getRelativePathSegments();
         }
 
         @Override
@@ -163,11 +215,47 @@ public final class GenericAdaptedApiHandlerTest {
         private StubHttpHandler(AdaptedApiHandler<StubHttpExchange> delegate) {
             this.delegate = delegate;
         }
+
+        private static final class StubPreArgStageBuilder
+                extends GenericAdaptedApiHandler.PreArgStageBuilder<StubHttpExchange, StubHttpHandler> {
+
+            @Override
+            protected GenericAdaptedApiHandler.SenderFactory<StubHttpExchange, Sender.StatusCode>
+                    getStatusCodeSenderFactory() {
+                return he -> FakeSender.StatusCode.create();
+            }
+
+            @Override
+            protected <V>
+                    GenericAdaptedApiHandler.SenderFactory<StubHttpExchange, Sender.Value<V>>
+                            getJsonValueSenderFactory() {
+                return StubPreArgStageBuilder::createJsonValueSender;
+            }
+
+            @Override
+            protected GenericAdaptedApiHandler.DispatcherFactory<StubHttpExchange> getDispatcherFactory() {
+                return he -> StubDispatcher.get();
+            }
+
+            @Override
+            protected GenericAdaptedApiHandler.HttpHandlerFactory<StubHttpExchange, StubHttpHandler>
+                    getHttpHandlerFactory() {
+                return StubHttpHandler::new;
+            }
+
+            @SuppressWarnings("unchecked")
+            private static <V> Sender.Value<V> createJsonValueSender(StubHttpExchange httpExchange) {
+                FakeSender.Value<V> sender = FakeSender.Value.create();
+                GenericAdaptedApiHandlerTest.sender = (FakeSender.Value<Object>) sender;
+                return sender;
+            }
+
+            private StubPreArgStageBuilder() {}
+        }
     }
 
     /** Stub HTTP exchange. */
     private record StubHttpExchange(
-            Sender.Value<Integer> sender,
             HttpOptional<Integer> maybeAddend1,
             HttpOptional<Integer> maybeAddend2,
             HttpOptional<Integer> maybeAddend3,
@@ -175,8 +263,7 @@ public final class GenericAdaptedApiHandlerTest {
             HttpOptional<Integer> maybeAddend5,
             HttpOptional<Integer> maybeAddend6,
             HttpOptional<Integer> maybeAddend7,
-            HttpOptional<Integer> maybeAddend8,
-            Dispatcher dispatcher) {
+            HttpOptional<Integer> maybeAddend8) {
 
         public static StubHttpExchange create(
                 String arg1,
@@ -187,7 +274,6 @@ public final class GenericAdaptedApiHandlerTest {
                 String arg6,
                 String arg7,
                 String arg8) {
-            Sender.Value<Integer> sender = GenericAdaptedApiHandlerTest.sender;
             HttpOptional<Integer> maybeAddend1 = tryExtractAddend(arg1);
             HttpOptional<Integer> maybeAddend2 = tryExtractAddend(arg2);
             HttpOptional<Integer> maybeAddend3 = tryExtractAddend(arg3);
@@ -196,9 +282,7 @@ public final class GenericAdaptedApiHandlerTest {
             HttpOptional<Integer> maybeAddend6 = tryExtractAddend(arg6);
             HttpOptional<Integer> maybeAddend7 = tryExtractAddend(arg7);
             HttpOptional<Integer> maybeAddend8 = tryExtractAddend(arg8);
-            Dispatcher dispatcher = GenericAdaptedApiHandlerTest.dispatcher;
             return new StubHttpExchange(
-                    sender,
                     maybeAddend1,
                     maybeAddend2,
                     maybeAddend3,
@@ -206,8 +290,7 @@ public final class GenericAdaptedApiHandlerTest {
                     maybeAddend5,
                     maybeAddend6,
                     maybeAddend7,
-                    maybeAddend8,
-                    dispatcher);
+                    maybeAddend8);
         }
 
         private static HttpOptional<Integer> tryExtractAddend(String arg) {

--- a/drift/src/test/java/io/github/mikewacker/drift/endpoint/GreetingHandler.java
+++ b/drift/src/test/java/io/github/mikewacker/drift/endpoint/GreetingHandler.java
@@ -7,10 +7,17 @@ import io.undertow.server.HttpHandler;
 final class GreetingHandler {
 
     public static HttpHandler create() {
-        HttpHandler greetingHandler = UndertowJsonApiHandler.builder(new TypeReference<String>() {})
-                .addArg(UndertowArgs.body(new TypeReference<String>() {}))
-                .build(Greeter::sendGreeting);
-        HttpHandler healthHandler = UndertowJsonApiHandler.builder().build(Greeter::healthCheck);
+        HttpHandler greetingHandler = UndertowJsonApiHandler.builder()
+                .route(HttpMethod.POST, "/greeting")
+                .jsonResponse(new TypeReference<String>() {})
+                .arg(UndertowArgs.body(new TypeReference<String>() {}))
+                .apiHandler(Greeter::sendGreeting)
+                .build();
+        HttpHandler healthHandler = UndertowJsonApiHandler.builder()
+                .route(HttpMethod.GET, "/health")
+                .statusCodeResponse()
+                .apiHandler(Greeter::healthCheck)
+                .build();
 
         return UndertowRouter.builder()
                 .addRoute(HttpMethod.POST, "/greeting", greetingHandler)

--- a/example/src/main/java/io/github/mikewacker/drift/example/GreetingEndpoint.java
+++ b/example/src/main/java/io/github/mikewacker/drift/example/GreetingEndpoint.java
@@ -15,10 +15,17 @@ public final class GreetingEndpoint {
     public static HttpHandler create(Supplier<String> salutationUrlProvider) {
         GreetingApi greetingApi = GreetingService.create(salutationUrlProvider);
 
-        HttpHandler greetingHandler = UndertowJsonApiHandler.builder(new TypeReference<String>() {})
-                .addArg(UndertowArgs.body(new TypeReference<String>() {}))
-                .build(greetingApi::sendGreeting);
-        HttpHandler healthHandler = UndertowJsonApiHandler.builder().build(greetingApi::healthCheck);
+        HttpHandler greetingHandler = UndertowJsonApiHandler.builder()
+                .route(HttpMethod.POST, "/greeting")
+                .jsonResponse(new TypeReference<String>() {})
+                .arg(UndertowArgs.body(new TypeReference<String>() {}))
+                .apiHandler(greetingApi::sendGreeting)
+                .build();
+        HttpHandler healthHandler = UndertowJsonApiHandler.builder()
+                .route(HttpMethod.GET, "/health")
+                .statusCodeResponse()
+                .apiHandler(greetingApi::healthCheck)
+                .build();
 
         return UndertowRouter.builder()
                 .addRoute(HttpMethod.POST, "/greeting", greetingHandler)


### PR DESCRIPTION
API changes:

- `builder()`/`build()` now have no arguments.
- New stages:
    - `route()`
    - `statusCodeResponse()`/`jsonResponse()`
    - `arg()`{0,8} (prev. `addArg()`)
    - `apiHandler()`: type aligns with the previous `*response()`/`arg()` calls
- Add `Stage` to the name of all builder interfaces. 