### PR TITLE
refine interface for JsonApiClient--and BackendDispatcher

### DIFF
--- a/drift/src/main/java/io/github/mikewacker/drift/backend/BackendDispatcher.java
+++ b/drift/src/main/java/io/github/mikewacker/drift/backend/BackendDispatcher.java
@@ -5,7 +5,7 @@ import io.github.mikewacker.drift.api.ApiHandler;
 import io.github.mikewacker.drift.api.Dispatcher;
 import io.github.mikewacker.drift.api.HttpOptional;
 import io.github.mikewacker.drift.api.Sender;
-import io.github.mikewacker.drift.client.ApiClient;
+import io.github.mikewacker.drift.client.BaseJsonApiClient;
 
 /**
  * A dispatcher for a frontend request that can asynchronously send backend requests to a backend server.
@@ -14,7 +14,7 @@ import io.github.mikewacker.drift.client.ApiClient;
  * <p>
  * The frontend server should create and share a single {@code BackendDispatcher}; each instance creates a new client.
  */
-public interface BackendDispatcher extends ApiClient {
+public interface BackendDispatcher extends BaseJsonApiClient {
 
     /**
      * Creates a dispatcher.
@@ -26,20 +26,22 @@ public interface BackendDispatcher extends ApiClient {
     }
 
     /**
-     * Creates a staged builder for a backend JSON API request whose response is only an HTTP status code.
+     * Creates a staged builder for a backend JSON API request.
      *
-     * @return a backend request builder at the initial stage
+     * @return a backend request builder at the response type stage
      */
-    UrlStageRequestBuilder<DispatchStage<Integer>> requestBuilder();
+    ResponseTypeStageRequestBuilder requestBuilder();
 
-    /**
-     * Creates a staged builder for a backend JSON API request whose response is an {@link HttpOptional} value.
-     *
-     * @param responseValueTypeRef a {@link TypeReference} for the backend response value
-     * @return a backend request builder at the initial stage
-     * @param <V> the type of the backend response value
-     */
-    <V> UrlStageRequestBuilder<DispatchStage<HttpOptional<V>>> requestBuilder(TypeReference<V> responseValueTypeRef);
+    /** Staged builder for a backend JSON API request that can set the type of the response. */
+    interface ResponseTypeStageRequestBuilder extends BaseResponseTypeStageRequestBuilder {
+
+        @Override
+        RouteStageRequestBuilder<DispatchStage<Integer>> statusCodeResponse();
+
+        @Override
+        <V> RouteStageRequestBuilder<DispatchStage<HttpOptional<V>>> jsonResponse(
+                TypeReference<V> responseValueTypeRef);
+    }
 
     /**
      * Post-build stage that can asynchronously send this backend request.

--- a/drift/src/main/java/io/github/mikewacker/drift/client/BaseJsonApiClient.java
+++ b/drift/src/main/java/io/github/mikewacker/drift/client/BaseJsonApiClient.java
@@ -1,20 +1,55 @@
 package io.github.mikewacker.drift.client;
 
-/** HTTP client for an API. The staged request builder includes a post-build stage that can send the request. */
-public interface ApiClient {
+import com.fasterxml.jackson.core.type.TypeReference;
+import io.github.mikewacker.drift.api.HttpOptional;
+
+/**
+ * HTTP client for an JSON API. The staged request builder includes a post-build stage that can send the request.
+ * <p>
+ * A sub-interface will...
+ * <ul>
+ *     <li>define a sub-interface for {@link BaseResponseTypeStageRequestBuilder}.
+ *     <li>provide a {@code requestBuilder()} method that returns said sub-interface.
+ * </ul>
+ */
+public interface BaseJsonApiClient {
 
     /**
-     * Staged builder for an API request that can set the HTTP method and the URL together.
+     * Staged builder for a JSON API request that can set the type of the response.
+     * <p>
+     * A sub-interface will override the return type to {@code RouteStageRequestBuilder<S>} and bind {@code S}.
+     */
+    interface BaseResponseTypeStageRequestBuilder {
+
+        /**
+         * Sets the type of the response to only an HTTP status code.
+         *
+         * @return this request builder at the route stage
+         */
+        Object statusCodeResponse();
+
+        /**
+         * Sets the type of the response to an {@link HttpOptional} value that is deserialized from JSON.
+         *
+         * @param responseValueTypeRef a {@link TypeReference} for the response value
+         * @return this request builder at the route stage
+         * @param <V> the type of the response value
+         */
+        <V> Object jsonResponse(TypeReference<V> responseValueTypeRef);
+    }
+
+    /**
+     * Staged builder for a JSON API request that can set the route: the HTTP method and the URL.
      *
      * @param <S> the interface for the post-build stage that can send this request
      */
-    interface UrlStageRequestBuilder<S> {
+    interface RouteStageRequestBuilder<S> {
 
         /**
          * Uses a GET request at the specified URL.
          *
          * @param url the URL for this request
-         * @return the next stage of this request builder
+         * @return this request builder at the headers or final stage
          */
         HeadersOrFinalStageRequestBuilder<S> get(String url);
 
@@ -22,7 +57,7 @@ public interface ApiClient {
          * Uses a PUT request at the specified URL.
          *
          * @param url the URL for this request
-         * @return the next stage of this request builder
+         * @return this request builder at the headers, body, or final stage
          */
         HeadersOrBodyOrFinalStageRequestBuilder<S> put(String url);
 
@@ -30,7 +65,7 @@ public interface ApiClient {
          * Uses a POST request at the specified URL.
          *
          * @param url the URL for this request
-         * @return the next stage of this request builder
+         * @return this request builder at the headers, body, or final stage
          */
         HeadersOrBodyOrFinalStageRequestBuilder<S> post(String url);
 
@@ -38,7 +73,7 @@ public interface ApiClient {
          * Uses a DELETE request at the specified URL.
          *
          * @param url the URL for this request
-         * @return the next stage of this request builder
+         * @return this request builder at the headers, body, or final stage
          */
         HeadersOrBodyOrFinalStageRequestBuilder<S> delete(String url);
 
@@ -46,7 +81,7 @@ public interface ApiClient {
          * Uses a PATCH request at the specified URL.
          *
          * @param url the URL for this request
-         * @return the next stage of this request builder
+         * @return this request builder at the headers, body, or final stage
          */
         HeadersOrBodyOrFinalStageRequestBuilder<S> patch(String url);
 
@@ -54,13 +89,13 @@ public interface ApiClient {
          * Uses a HEAD request at the specified URL.
          *
          * @param url the URL for this request
-         * @return the next stage of this request builder
+         * @return this request builder at the headers or final stage
          */
         HeadersOrFinalStageRequestBuilder<S> head(String url);
     }
 
     /**
-     * Staged builder for an API request that can add headers or build this request.
+     * Staged builder for a JSON API request that can add headers or build this request.
      *
      * @param <S> the interface for the post-build stage that can send this request
      */
@@ -74,13 +109,13 @@ public interface ApiClient {
          *
          * @param name the name of the header
          * @param value the value of the header
-         * @return the same stage of this request builder
+         * @return this request builder at the headers or final stage
          */
         HeadersOrFinalStageRequestBuilder<S> header(String name, String value);
     }
 
     /**
-     * Staged builder for an API request that can add headers, set the body, or build this request.
+     * Staged builder for a JSON API request that can add headers, set the body, or build this request.
      *
      * @param <S> the interface for the post-build stage that can send this request
      */
@@ -94,13 +129,13 @@ public interface ApiClient {
          *
          * @param name the name of the header
          * @param value the value of the header
-         * @return the same stage of this request builder
+         * @return this request builder at the headers, body, or final stage
          */
         HeadersOrBodyOrFinalStageRequestBuilder<S> header(String name, String value);
     }
 
     /**
-     * Staged builder for an API request that can set the body or build this request.
+     * Staged builder for a JSON API request that can set the body or build this request.
      *
      * @param <S> the interface for the post-build stage that can send this request
      */
@@ -110,13 +145,13 @@ public interface ApiClient {
          * Sets the body using a value.
          *
          * @param requestValue the value that will be serialized and used as the body
-         * @return the next stage of this request builder
+         * @return this request builder at the final stage
          */
         FinalStageRequestBuilder<S> body(Object requestValue);
     }
 
     /**
-     * Staged builder for an API request that can build this request.
+     * Staged builder for a JSON API request that can build this request.
      *
      * @param <S> the interface for the post-build stage that can send this request
      */

--- a/drift/src/main/java/io/github/mikewacker/drift/client/JsonApiClient.java
+++ b/drift/src/main/java/io/github/mikewacker/drift/client/JsonApiClient.java
@@ -6,27 +6,25 @@ import io.github.mikewacker.drift.json.JsonSerializationException;
 import java.io.IOException;
 
 /** Shared HTTP client that sends requests to a JSON API. */
-public interface JsonApiClient extends ApiClient {
+public interface JsonApiClient extends BaseJsonApiClient {
 
     /**
-     * Creates a staged builder for a JSON API request whose response is only an HTTP status code.
+     * Creates a staged builder for a JSON API request.
      *
-     * @return a request builder at the initial stage
+     * @return a request builder at the response type stage
      */
-    static UrlStageRequestBuilder<SendStage<Integer>> requestBuilder() {
+    static ResponseTypeStageRequestBuilder requestBuilder() {
         return JsonApiClientImpl.requestBuilder();
     }
 
-    /**
-     * Creates a staged builder for a JSON API request whose response is an {@link HttpOptional} value.
-     *
-     * @param responseValueTypeRef a {@link TypeReference} for the response value
-     * @return a request builder at the initial stage
-     * @param <V> the type of the response value
-     */
-    static <V> UrlStageRequestBuilder<SendStage<HttpOptional<V>>> requestBuilder(
-            TypeReference<V> responseValueTypeRef) {
-        return JsonApiClientImpl.requestBuilder(responseValueTypeRef);
+    /** Staged builder for a JSON API request that can set the type of the response. */
+    interface ResponseTypeStageRequestBuilder extends BaseResponseTypeStageRequestBuilder {
+
+        @Override
+        RouteStageRequestBuilder<SendStage<Integer>> statusCodeResponse();
+
+        @Override
+        <V> RouteStageRequestBuilder<SendStage<HttpOptional<V>>> jsonResponse(TypeReference<V> responseValueTypeRef);
     }
 
     /**

--- a/drift/src/main/java/io/github/mikewacker/drift/client/JsonApiClientImpl.java
+++ b/drift/src/main/java/io/github/mikewacker/drift/client/JsonApiClientImpl.java
@@ -3,7 +3,6 @@ package io.github.mikewacker.drift.client;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.github.mikewacker.drift.api.HttpOptional;
 import java.io.IOException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -11,44 +10,37 @@ import okhttp3.Response;
 /** Internal {@code JsonApiClient} implementation. */
 final class JsonApiClientImpl extends AbstractOkHttpJsonApiClient implements JsonApiClient {
 
-    private static final JsonApiClientImpl instance = new JsonApiClientImpl();
-
     private static final OkHttpClient client = new OkHttpClient();
 
     /** Corresponds to {@code JsonApiClient#requestBuilder()}. */
-    public static UrlStageRequestBuilder<SendStage<Integer>> requestBuilder() {
-        return instance.requestBuilder(SendStageImpl::new);
-    }
-
-    /** Corresponds to {@code JsonApiClient#requestBuilder(TypeReference)}. */
-    public static <V> UrlStageRequestBuilder<SendStage<HttpOptional<V>>> requestBuilder(
-            TypeReference<V> responseValueTypeRef) {
-        return instance.requestBuilder(SendStageImpl::new, responseValueTypeRef);
+    public static ResponseTypeStageRequestBuilder requestBuilder() {
+        return new ResponseTypeStageRequestBuilderImpl();
     }
 
     private JsonApiClientImpl() {}
 
+    /** Internal {@code ResponseTypeStageRequestBuilder} implementation. */
+    private static final class ResponseTypeStageRequestBuilderImpl implements ResponseTypeStageRequestBuilder {
+
+        @Override
+        public RouteStageRequestBuilder<SendStage<Integer>> statusCodeResponse() {
+            return AbstractOkHttpJsonApiClient.statusCodeResponse(SendStageImpl::new);
+        }
+
+        @Override
+        public <V> RouteStageRequestBuilder<SendStage<HttpOptional<V>>> jsonResponse(
+                TypeReference<V> responseValueTypeRef) {
+            return AbstractOkHttpJsonApiClient.jsonResponse(SendStageImpl::new, responseValueTypeRef);
+        }
+    }
+
     /** Internal {@code SendStage} implementation. */
-    private static final class SendStageImpl<R> implements SendStage<R> {
-
-        private final Request rawRequest;
-        private final ResponseAdapter<R> responseAdapter;
-
-        private final AtomicBoolean wasSent = new AtomicBoolean(false);
+    private record SendStageImpl<R>(Request rawRequest, ResponseAdapter<R> responseAdapter) implements SendStage<R> {
 
         @Override
         public R execute() throws IOException {
-            if (wasSent.getAndSet(true)) {
-                throw new IllegalStateException("request was already sent");
-            }
-
             Response rawResponse = client.newCall(rawRequest).execute();
             return responseAdapter.convert(rawResponse);
-        }
-
-        private SendStageImpl(Request rawRequest, ResponseAdapter<R> responseAdapter) {
-            this.rawRequest = rawRequest;
-            this.responseAdapter = responseAdapter;
         }
     }
 }

--- a/drift/src/test/java/io/github/mikewacker/drift/backend/BackendDispatcherTest.java
+++ b/drift/src/test/java/io/github/mikewacker/drift/backend/BackendDispatcherTest.java
@@ -55,13 +55,15 @@ public final class BackendDispatcherTest {
 
     private static int executeRequestWithStatusCodeResponse() throws IOException {
         return JsonApiClient.requestBuilder()
+                .statusCodeResponse()
                 .get(frontendServer.url("/status-code"))
                 .build()
                 .execute();
     }
 
     private static HttpOptional<String> executeRequestWithJsonValueResponse() throws IOException {
-        return JsonApiClient.requestBuilder(new TypeReference<String>() {})
+        return JsonApiClient.requestBuilder()
+                .jsonResponse(new TypeReference<String>() {})
                 .get(frontendServer.url("/text"))
                 .build()
                 .execute();

--- a/drift/src/test/java/io/github/mikewacker/drift/client/JsonApiClientTest.java
+++ b/drift/src/test/java/io/github/mikewacker/drift/client/JsonApiClientTest.java
@@ -25,8 +25,11 @@ public final class JsonApiClientTest {
     @Test
     public void statusCodeResponse() throws IOException {
         mockServer.enqueue(new MockResponse());
-        int statusCode =
-                JsonApiClient.requestBuilder().get(mockServer.rootUrl()).build().execute();
+        int statusCode = JsonApiClient.requestBuilder()
+                .statusCodeResponse()
+                .get(mockServer.rootUrl())
+                .build()
+                .execute();
         assertThat(statusCode).isEqualTo(200);
     }
 
@@ -34,7 +37,8 @@ public final class JsonApiClientTest {
     public void jsonValueResponse_Ok() throws IOException {
         mockServer.enqueue(
                 new MockResponse().setHeader("Content-Type", "application/json").setBody("\"test\""));
-        HttpOptional<String> maybeText = JsonApiClient.requestBuilder(new TypeReference<String>() {})
+        HttpOptional<String> maybeText = JsonApiClient.requestBuilder()
+                .jsonResponse(new TypeReference<String>() {})
                 .get(mockServer.rootUrl())
                 .build()
                 .execute();
@@ -44,7 +48,8 @@ public final class JsonApiClientTest {
     @Test
     public void jsonValueResponse_ErrorCode() throws IOException {
         mockServer.enqueue(new MockResponse().setResponseCode(500));
-        HttpOptional<String> maybeText = JsonApiClient.requestBuilder(new TypeReference<String>() {})
+        HttpOptional<String> maybeText = JsonApiClient.requestBuilder()
+                .jsonResponse(new TypeReference<String>() {})
                 .get(mockServer.rootUrl())
                 .build()
                 .execute();
@@ -53,65 +58,59 @@ public final class JsonApiClientTest {
 
     @Test
     public void get() throws Exception {
-        method(
-                () -> JsonApiClient.requestBuilder()
-                        .get(mockServer.rootUrl())
-                        .build()
-                        .execute(),
-                "GET");
+        method("GET", () -> JsonApiClient.requestBuilder()
+                .statusCodeResponse()
+                .get(mockServer.rootUrl())
+                .build()
+                .execute());
     }
 
     @Test
     public void put() throws Exception {
-        method(
-                () -> JsonApiClient.requestBuilder()
-                        .put(mockServer.rootUrl())
-                        .build()
-                        .execute(),
-                "PUT");
+        method("PUT", () -> JsonApiClient.requestBuilder()
+                .statusCodeResponse()
+                .put(mockServer.rootUrl())
+                .build()
+                .execute());
     }
 
     @Test
     public void post() throws Exception {
-        method(
-                () -> JsonApiClient.requestBuilder()
-                        .post(mockServer.rootUrl())
-                        .build()
-                        .execute(),
-                "POST");
+        method("POST", () -> JsonApiClient.requestBuilder()
+                .statusCodeResponse()
+                .post(mockServer.rootUrl())
+                .build()
+                .execute());
     }
 
     @Test
     public void delete() throws Exception {
-        method(
-                () -> JsonApiClient.requestBuilder()
-                        .delete(mockServer.rootUrl())
-                        .build()
-                        .execute(),
-                "DELETE");
+        method("DELETE", () -> JsonApiClient.requestBuilder()
+                .statusCodeResponse()
+                .delete(mockServer.rootUrl())
+                .build()
+                .execute());
     }
 
     @Test
     public void patch() throws Exception {
-        method(
-                () -> JsonApiClient.requestBuilder()
-                        .patch(mockServer.rootUrl())
-                        .build()
-                        .execute(),
-                "PATCH");
+        method("PATCH", () -> JsonApiClient.requestBuilder()
+                .statusCodeResponse()
+                .patch(mockServer.rootUrl())
+                .build()
+                .execute());
     }
 
     @Test
     public void head() throws Exception {
-        method(
-                () -> JsonApiClient.requestBuilder()
-                        .head(mockServer.rootUrl())
-                        .build()
-                        .execute(),
-                "HEAD");
+        method("HEAD", () -> JsonApiClient.requestBuilder()
+                .statusCodeResponse()
+                .head(mockServer.rootUrl())
+                .build()
+                .execute());
     }
 
-    private void method(Callable<Integer> requestSender, String expectedMethod) throws Exception {
+    private void method(String expectedMethod, Callable<Integer> requestSender) throws Exception {
         mockServer.enqueue(new MockResponse());
         int statusCode = requestSender.call();
         assertThat(statusCode).isEqualTo(200);
@@ -124,6 +123,7 @@ public final class JsonApiClientTest {
     public void headers() throws Exception {
         mockServer.enqueue(new MockResponse());
         int statusCode = JsonApiClient.requestBuilder()
+                .statusCodeResponse()
                 .get(mockServer.rootUrl())
                 .header("User-Agent", "agent")
                 .header("Test-Header", "value")
@@ -140,6 +140,7 @@ public final class JsonApiClientTest {
     public void body() throws Exception {
         mockServer.enqueue(new MockResponse());
         int statusCode = JsonApiClient.requestBuilder()
+                .statusCodeResponse()
                 .post(mockServer.rootUrl())
                 .body("test")
                 .build()
@@ -178,33 +179,13 @@ public final class JsonApiClientTest {
     }
 
     private void error_JsonValueResponse(String expectedMessagePrefix) {
-        assertThatThrownBy(() -> JsonApiClient.requestBuilder(new TypeReference<String>() {})
+        assertThatThrownBy(() -> JsonApiClient.requestBuilder()
+                        .jsonResponse(new TypeReference<String>() {})
                         .get(mockServer.rootUrl())
                         .build()
                         .execute())
                 .isInstanceOf(JsonSerializationException.class)
                 .hasMessageStartingWith(expectedMessagePrefix);
-    }
-
-    @Test
-    public void error_StageCompleted() {
-        ApiClient.UrlStageRequestBuilder<JsonApiClient.SendStage<Integer>> requestBuilder =
-                JsonApiClient.requestBuilder();
-        requestBuilder.get(mockServer.rootUrl());
-        assertThatThrownBy(() -> requestBuilder.get(mockServer.rootUrl()))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("stage already completed");
-    }
-
-    @Test
-    public void error_SendRequestTwice() throws IOException {
-        mockServer.enqueue(new MockResponse());
-        JsonApiClient.SendStage<Integer> requestSender =
-                JsonApiClient.requestBuilder().get(mockServer.rootUrl()).build();
-        requestSender.execute();
-        assertThatThrownBy(requestSender::execute)
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage("request was already sent");
     }
 
     private static RecordedRequest takeRecordedRequest() throws InterruptedException {

--- a/drift/src/test/java/io/github/mikewacker/drift/endpoint/UndertowArgsTest.java
+++ b/drift/src/test/java/io/github/mikewacker/drift/endpoint/UndertowArgsTest.java
@@ -30,7 +30,8 @@ public final class UndertowArgsTest {
     @Test
     public void body() throws IOException {
         set(UndertowArgs.body(new TypeReference<>() {}));
-        HttpOptional<Integer> maybeArg = JsonApiClient.requestBuilder(new TypeReference<Integer>() {})
+        HttpOptional<Integer> maybeArg = JsonApiClient.requestBuilder()
+                .jsonResponse(new TypeReference<Integer>() {})
                 .put(server.rootUrl())
                 .body(1)
                 .build()
@@ -41,7 +42,8 @@ public final class UndertowArgsTest {
     @Test
     public void queryParam() throws IOException {
         set(UndertowArgs.queryParam("param", new TypeReference<>() {}));
-        HttpOptional<Integer> maybeArg = JsonApiClient.requestBuilder(new TypeReference<Integer>() {})
+        HttpOptional<Integer> maybeArg = JsonApiClient.requestBuilder()
+                .jsonResponse(new TypeReference<Integer>() {})
                 .get(server.url("/path?param=1"))
                 .build()
                 .execute();
@@ -51,7 +53,8 @@ public final class UndertowArgsTest {
     @Test
     public void badRequest_Body_DeserializeFailed() throws IOException {
         set(UndertowArgs.body(new TypeReference<>() {}));
-        HttpOptional<Integer> maybeArg = JsonApiClient.requestBuilder(new TypeReference<Integer>() {})
+        HttpOptional<Integer> maybeArg = JsonApiClient.requestBuilder()
+                .jsonResponse(new TypeReference<Integer>() {})
                 .put(server.rootUrl())
                 .body("a")
                 .build()
@@ -62,7 +65,8 @@ public final class UndertowArgsTest {
     @Test
     public void badRequest_QueryParam_Missing() throws IOException {
         set(UndertowArgs.queryParam("param", new TypeReference<>() {}));
-        HttpOptional<Integer> maybeArg = JsonApiClient.requestBuilder(new TypeReference<Integer>() {})
+        HttpOptional<Integer> maybeArg = JsonApiClient.requestBuilder()
+                .jsonResponse(new TypeReference<Integer>() {})
                 .get(server.rootUrl())
                 .build()
                 .execute();
@@ -72,7 +76,8 @@ public final class UndertowArgsTest {
     @Test
     public void badRequest_QueryParam_MultipleValues() throws IOException {
         set(UndertowArgs.queryParam("param", new TypeReference<>() {}));
-        HttpOptional<Integer> maybeArg = JsonApiClient.requestBuilder(new TypeReference<Integer>() {})
+        HttpOptional<Integer> maybeArg = JsonApiClient.requestBuilder()
+                .jsonResponse(new TypeReference<Integer>() {})
                 .get(server.url("/path?param=1&param=2"))
                 .build()
                 .execute();
@@ -82,7 +87,8 @@ public final class UndertowArgsTest {
     @Test
     public void badRequest_QueryParam_DeserializeFailed() throws IOException {
         set(UndertowArgs.queryParam("param", new TypeReference<>() {}));
-        HttpOptional<Integer> maybeArg = JsonApiClient.requestBuilder(new TypeReference<Integer>() {})
+        HttpOptional<Integer> maybeArg = JsonApiClient.requestBuilder()
+                .jsonResponse(new TypeReference<Integer>() {})
                 .get(server.url("/path?param=a"))
                 .build()
                 .execute();

--- a/drift/src/test/java/io/github/mikewacker/drift/endpoint/UndertowDispatcherTest.java
+++ b/drift/src/test/java/io/github/mikewacker/drift/endpoint/UndertowDispatcherTest.java
@@ -54,7 +54,8 @@ public final class UndertowDispatcherTest {
     }
 
     private static HttpOptional<String> executeRequest(String path) throws IOException {
-        return JsonApiClient.requestBuilder(new TypeReference<String>() {})
+        return JsonApiClient.requestBuilder()
+                .jsonResponse(new TypeReference<String>() {})
                 .get(server.url(path))
                 .build()
                 .execute();

--- a/drift/src/test/java/io/github/mikewacker/drift/endpoint/UndertowJsonApiTest.java
+++ b/drift/src/test/java/io/github/mikewacker/drift/endpoint/UndertowJsonApiTest.java
@@ -20,6 +20,7 @@ public final class UndertowJsonApiTest {
     @Test
     public void exchange_StatusCode() throws IOException {
         int statusCode = JsonApiClient.requestBuilder()
+                .statusCodeResponse()
                 .get(server.url("/health"))
                 .build()
                 .execute();
@@ -28,7 +29,8 @@ public final class UndertowJsonApiTest {
 
     @Test
     public void exchange_JsonValue() throws IOException {
-        HttpOptional<String> maybeGreeting = JsonApiClient.requestBuilder(new TypeReference<String>() {})
+        HttpOptional<String> maybeGreeting = JsonApiClient.requestBuilder()
+                .jsonResponse(new TypeReference<String>() {})
                 .post(server.url("/greeting"))
                 .body("world")
                 .build()

--- a/drift/src/test/java/io/github/mikewacker/drift/endpoint/UndertowSenderTest.java
+++ b/drift/src/test/java/io/github/mikewacker/drift/endpoint/UndertowSenderTest.java
@@ -58,11 +58,16 @@ public final class UndertowSenderTest {
     }
 
     private static int executeStatusCodeRequest(String path) throws IOException {
-        return JsonApiClient.requestBuilder().get(server.url(path)).build().execute();
+        return JsonApiClient.requestBuilder()
+                .statusCodeResponse()
+                .get(server.url(path))
+                .build()
+                .execute();
     }
 
     private static HttpOptional<String> executeTextRequest(String path) throws IOException {
-        return JsonApiClient.requestBuilder(new TypeReference<String>() {})
+        return JsonApiClient.requestBuilder()
+                .jsonResponse(new TypeReference<String>() {})
                 .get(server.url(path))
                 .build()
                 .execute();

--- a/drift/src/testFixtures/java/io/github/mikewacker/drift/backend/ProxyService.java
+++ b/drift/src/testFixtures/java/io/github/mikewacker/drift/backend/ProxyService.java
@@ -20,6 +20,7 @@ final class ProxyService implements ProxyApi {
     public void proxyStatusCode(Sender.StatusCode sender, Dispatcher dispatcher) {
         backendDispatcher
                 .requestBuilder()
+                .statusCodeResponse()
                 .get(TestServer.get("backend").rootUrl())
                 .build()
                 .dispatch(sender, dispatcher, this::onStatusCodeReceived);
@@ -28,7 +29,8 @@ final class ProxyService implements ProxyApi {
     @Override
     public void proxyText(Sender.Value<String> sender, Dispatcher dispatcher) {
         backendDispatcher
-                .requestBuilder(new TypeReference<String>() {})
+                .requestBuilder()
+                .jsonResponse(new TypeReference<String>() {})
                 .get(TestServer.get("backend").rootUrl())
                 .build()
                 .dispatch(sender, dispatcher, this::onTextReceived);

--- a/example/src/main/java/io/github/mikewacker/drift/example/GreetingService.java
+++ b/example/src/main/java/io/github/mikewacker/drift/example/GreetingService.java
@@ -21,7 +21,8 @@ public final class GreetingService implements GreetingApi {
     @Override
     public void sendGreeting(Sender.Value<String> sender, String recipient, Dispatcher dispatcher) {
         backendDispatcher
-                .requestBuilder(new TypeReference<String>() {})
+                .requestBuilder()
+                .jsonResponse(new TypeReference<String>() {})
                 .get(salutationUrlProvider.get())
                 .build()
                 .dispatch(sender, recipient, dispatcher, this::onSalutationReceived);

--- a/example/src/test/java/io/github/mikewacker/drift/example/GreetingTest.java
+++ b/example/src/test/java/io/github/mikewacker/drift/example/GreetingTest.java
@@ -29,7 +29,8 @@ public final class GreetingTest {
     public void helloWorld() throws IOException {
         salutationServer.enqueue(
                 new MockResponse().setHeader("Content-Type", "application/json").setBody("\"Hello\""));
-        HttpOptional<String> maybeGreeting = JsonApiClient.requestBuilder(new TypeReference<String>() {})
+        HttpOptional<String> maybeGreeting = JsonApiClient.requestBuilder()
+                .jsonResponse(new TypeReference<String>() {})
                 .post(greetingServer.url("/greeting"))
                 .body("world")
                 .build()
@@ -40,6 +41,7 @@ public final class GreetingTest {
     @Test
     public void healthCheck() throws IOException {
         int statusCode = JsonApiClient.requestBuilder()
+                .statusCodeResponse()
                 .get(greetingServer.url("/health"))
                 .build()
                 .execute();


### PR DESCRIPTION
Add a response type stage (`statusCodeResponse()`/`jsonResponse(TypeReference<V>)`), which improves the readability. Corollary: `s/ApiClient/BaseJsonApiClient/g`. Also simplify the implementation a bit.

Note: The DRY design challenge is creating an abstract class that implements `BaseJsonApiClient` according to its signature, but actually implements a sub-interface of `BaseJsonApiClient` in practice; `BaseJsonApiClient` has two sub-interfaces. The main complexifier is that if a generic method has multiple type parameters, an override of that method cannot partially bind the type parameters (e.g., bind `S` but not `V`).